### PR TITLE
build: add release bundle workflow and paimon-cpp patches

### DIFF
--- a/.github/workflows/release-bundle.yml
+++ b/.github/workflows/release-bundle.yml
@@ -1,0 +1,128 @@
+name: Release Paimon Extension Bundle
+
+env:
+  duckdb_version: v1.5.1
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build-bundles:
+    name: Build and package (${{ matrix.bundle_arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - bundle_arch: linux-amd64
+            runner: ubuntu-22.04
+          - bundle_arch: linux-arm64
+            runner: ubuntu-22.04-arm
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Set release tag
+        id: tag
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            echo "value=${GITHUB_REF_NAME}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "value=${{ inputs.tag }}" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Ensure DuckDB version metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          git -C duckdb fetch --force --tags
+          git -C duckdb describe --tags --long
+
+      - name: Build extension (release)
+        shell: bash
+        run: |
+          GEN=ninja make
+
+      - name: Package release bundle
+        id: package
+        env:
+          EXT_DIR: build/release/extension/paimon
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TAG="${{ steps.tag.outputs.value }}"
+          PKG_NAME="duckdb-paimon-${TAG}-${duckdb_version}-${{ matrix.bundle_arch }}"
+          STAGE_DIR="dist/${PKG_NAME}"
+
+          mkdir -p "${STAGE_DIR}"
+
+          cp "${EXT_DIR}/paimon.duckdb_extension" "${STAGE_DIR}/"
+          cp "${EXT_DIR}"/libpaimon*.so* "${STAGE_DIR}/"
+          cp "${EXT_DIR}"/libjindosdk_c.so* "${STAGE_DIR}/"
+
+          cp LICENSE "${STAGE_DIR}/LICENSE"
+          cp README.md "${STAGE_DIR}/README.md"
+
+          tar -C dist -czf "dist/${PKG_NAME}.tar.gz" "${PKG_NAME}"
+          sha256sum "dist/${PKG_NAME}.tar.gz" > "dist/${PKG_NAME}.tar.gz.sha256"
+
+          echo "archive=dist/${PKG_NAME}.tar.gz" >> "${GITHUB_OUTPUT}"
+          echo "checksum=dist/${PKG_NAME}.tar.gz.sha256" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-${{ matrix.bundle_arch }}
+          path: |
+            ${{ steps.package.outputs.archive }}
+            ${{ steps.package.outputs.checksum }}
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-release:
+    name: Publish GitHub release assets
+    runs-on: ubuntu-22.04
+    needs: build-bundles
+    steps:
+      - name: Set release tag
+        id: tag
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            echo "value=${GITHUB_REF_NAME}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "value=${{ inputs.tag }}" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Download all packaged artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: dist
+          pattern: release-*
+          merge-multiple: true
+
+      - name: Publish to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.value }}
+          target_commitish: ${{ github.sha }}
+          generate_release_notes: true
+          files: |
+            dist/*.tar.gz
+            dist/*.tar.gz.sha256

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,9 @@ set(PAIMON_CPP_LIB ${PAIMON_CPP_PREFIX}/lib64)
 file(MAKE_DIRECTORY ${PAIMON_CPP_INCLUDE})
 
 set(PAIMON_CPP_PATCHES
-  ${CMAKE_CURRENT_SOURCE_DIR}/patches/paimon-cpp-install-arrow-headers.patch)
+  ${CMAKE_CURRENT_SOURCE_DIR}/patches/paimon-cpp-install-arrow-headers.patch
+  ${CMAKE_CURRENT_SOURCE_DIR}/patches/paimon-cpp-link-arrow-brotli-libs.patch
+  ${CMAKE_CURRENT_SOURCE_DIR}/patches/paimon-cpp-disable-glog-unwind.patch)
 
 # Build patch command: apply each patch idempotently
 set(PAIMON_CPP_PATCH_SCRIPT "")
@@ -40,6 +42,7 @@ ExternalProject_Add(paimon_cpp_ep
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     -DCMAKE_INSTALL_PREFIX=${PAIMON_CPP_PREFIX}
     -DCMAKE_INSTALL_LIBDIR=lib64
+    -DLIBUNWIND_LIBRARY=FALSE
     -DPAIMON_BUILD_TESTS=OFF
     -DPAIMON_BUILD_SHARED=ON
     -DPAIMON_BUILD_STATIC=OFF
@@ -98,6 +101,35 @@ set(PAIMON_CPP_LIBS
 )
 target_link_libraries(${EXTENSION_NAME} ${PAIMON_CPP_LIBS})
 target_link_libraries(${TARGET_NAME}_loadable_extension ${PAIMON_CPP_LIBS})
+
+# Bundle paimon-cpp runtime dependencies next to paimon.duckdb_extension.
+set(PAIMON_CPP_RUNTIME_BUNDLE_LIBS
+  ${PAIMON_CPP_LIB}/libpaimon.so
+  ${PAIMON_CPP_LIB}/libpaimon_local_file_system.so
+  ${PAIMON_CPP_LIB}/libpaimon_jindo_file_system.so
+  ${PAIMON_CPP_LIB}/libjindosdk_c.so.6
+  ${PAIMON_CPP_LIB}/libpaimon_parquet_file_format.so
+  ${PAIMON_CPP_LIB}/libpaimon_orc_file_format.so
+  ${PAIMON_CPP_LIB}/libpaimon_avro_file_format.so
+  ${PAIMON_CPP_LIB}/libpaimon_blob_file_format.so
+)
+foreach(lib IN LISTS PAIMON_CPP_RUNTIME_BUNDLE_LIBS)
+  add_custom_command(
+    TARGET ${TARGET_NAME}_loadable_extension
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      ${lib}
+      $<TARGET_FILE_DIR:${TARGET_NAME}_loadable_extension>
+  )
+endforeach()
+
+# Make runtime library lookup relocatable for the shipped loadable extension.
+set_target_properties(${TARGET_NAME}_loadable_extension PROPERTIES
+  BUILD_RPATH "\$ORIGIN"
+  INSTALL_RPATH "\$ORIGIN"
+  BUILD_WITH_INSTALL_RPATH ON
+  INSTALL_RPATH_USE_LINK_PATH OFF
+)
 
 install(
   TARGETS ${EXTENSION_NAME}

--- a/patches/paimon-cpp-disable-glog-unwind.patch
+++ b/patches/paimon-cpp-disable-glog-unwind.patch
@@ -1,0 +1,11 @@
+diff --git a/cmake_modules/ThirdpartyToolchain.cmake b/cmake_modules/ThirdpartyToolchain.cmake
+--- a/cmake_modules/ThirdpartyToolchain.cmake
++++ b/cmake_modules/ThirdpartyToolchain.cmake
+@@ -1387,6 +1387,7 @@ macro(build_glog)
+         ${EP_COMMON_CMAKE_ARGS}
+         -DCMAKE_INSTALL_PREFIX=${GLOG_PREFIX}
+         -DWITH_GFLAGS=OFF
++        -DWITH_UNWIND=OFF
+         -DWITH_GTEST=OFF
+         -DCMAKE_CXX_FLAGS=${GLOG_CMAKE_CXX_FLAGS}
+         -DCMAKE_C_FLAGS=${GLOG_CMAKE_C_FLAGS})

--- a/patches/paimon-cpp-link-arrow-brotli-libs.patch
+++ b/patches/paimon-cpp-link-arrow-brotli-libs.patch
@@ -1,0 +1,69 @@
+diff --git a/cmake_modules/ThirdpartyToolchain.cmake b/cmake_modules/ThirdpartyToolchain.cmake
+index 09f7fb0..9c568ee 100644
+--- a/cmake_modules/ThirdpartyToolchain.cmake
++++ b/cmake_modules/ThirdpartyToolchain.cmake
+@@ -1107,6 +1107,17 @@ macro(build_arrow)
+     set(PARQUET_STATIC_LIB
+         "${ARROW_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}parquet${CMAKE_STATIC_LIBRARY_SUFFIX}"
+     )
++    set(ARROW_BROTLI_PREFIX
++        "${CMAKE_CURRENT_BINARY_DIR}/arrow_ep-prefix/src/arrow_ep-build/brotli_ep/src/brotli_ep-install")
++    set(ARROW_BROTLI_DEC_STATIC_LIB
++        "${ARROW_BROTLI_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}brotlidec-static${CMAKE_STATIC_LIBRARY_SUFFIX}"
++    )
++    set(ARROW_BROTLI_ENC_STATIC_LIB
++        "${ARROW_BROTLI_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}brotlienc-static${CMAKE_STATIC_LIBRARY_SUFFIX}"
++    )
++    set(ARROW_BROTLI_COMMON_STATIC_LIB
++        "${ARROW_BROTLI_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}brotlicommon-static${CMAKE_STATIC_LIBRARY_SUFFIX}"
++    )
+ 
+     set(ARROW_CMAKE_ARGS
+         ${EP_COMMON_CMAKE_ARGS}
+@@ -1137,6 +1148,7 @@ macro(build_arrow)
+         -DARROW_WITH_ZSTD=ON
+         -DARROW_WITH_BZ2=OFF
+         -DARROW_WITH_BROTLI=ON
++        -DBrotli_SOURCE=BUNDLED
+         -DZSTD_ROOT=${ARROW_ZSTD_ROOT}
+         -DZLIB_ROOT=${ARROW_ZLIB_ROOT}
+         -DSnappy_ROOT=${ARROW_SNAPPY_ROOT}
+@@ -1157,6 +1169,9 @@ macro(build_arrow)
+                                          "${PARQUET_STATIC_LIB}"
+                                          "${ARROW_DATASET_STATIC_LIB}"
+                                          "${ARROW_ACERO_STATIC_LIB}"
++                                         "${ARROW_BROTLI_DEC_STATIC_LIB}"
++                                         "${ARROW_BROTLI_ENC_STATIC_LIB}"
++                                         "${ARROW_BROTLI_COMMON_STATIC_LIB}"
+                         DEPENDS zstd snappy lz4 zlib)
+ 
+     add_library(arrow STATIC IMPORTED)
+@@ -1203,6 +1218,18 @@ macro(build_arrow)
+     add_dependencies(arrow_dataset arrow_ep)
+     add_dependencies(arrow_acero arrow_ep)
+ 
++    add_library(brotlidec STATIC IMPORTED)
++    set_target_properties(brotlidec PROPERTIES IMPORTED_LOCATION "${ARROW_BROTLI_DEC_STATIC_LIB}")
++    add_dependencies(brotlidec arrow_ep)
++
++    add_library(brotlienc STATIC IMPORTED)
++    set_target_properties(brotlienc PROPERTIES IMPORTED_LOCATION "${ARROW_BROTLI_ENC_STATIC_LIB}")
++    add_dependencies(brotlienc arrow_ep)
++
++    add_library(brotlicommon STATIC IMPORTED)
++    set_target_properties(brotlicommon PROPERTIES IMPORTED_LOCATION "${ARROW_BROTLI_COMMON_STATIC_LIB}")
++    add_dependencies(brotlicommon arrow_ep)
++
+     target_link_libraries(arrow_acero INTERFACE arrow)
+ 
+     target_link_libraries(arrow_dataset INTERFACE arrow_acero)
+@@ -1212,6 +1239,9 @@ macro(build_arrow)
+                                     snappy
+                                     lz4
+                                     zlib
++                                    brotlidec
++                                    brotlienc
++                                    brotlicommon
+                                     arrow_bundled_dependencies)
+ 
+     target_link_libraries(parquet


### PR DESCRIPTION
Add a release-bundle workflow that builds linux-amd64 and linux-arm64 packages on Ubuntu 22.04 runners and publishes the resulting archives as GitHub release assets.

Patch paimon-cpp so Arrow links against bundled Brotli static libraries, disable glog libunwind support, and pass -DLIBUNWIND_LIBRARY=FALSE only to the paimon-cpp ExternalProject.