### PR TITLE
fix: release current batch before EOF handling

### DIFF
--- a/src/paimon_storage/paimon_scan.cpp
+++ b/src/paimon_storage/paimon_scan.cpp
@@ -251,6 +251,7 @@ public:
 				throw IOException(batch_result.status().ToString());
 			}
 			auto batch = std::move(batch_result).value();
+			ReleaseCurrentBatch();
 
 			// current split exhausted, try to grab the next one
 			if (paimon::BatchReader::IsEofBatch(batch)) {
@@ -262,7 +263,6 @@ public:
 				continue;
 			}
 
-			ReleaseCurrentBatch();
 			return batch;
 		}
 


### PR DESCRIPTION
Move ReleaseCurrentBatch() to run immediately after obtaining a batch and before checking EOF. This ensures the previous batch is always released even when the current split hits EOF and we continue to the next split.