### PR TITLE
fix(scan): release Arrow schema before conversion

### DIFF
--- a/src/paimon_storage/paimon_scan.cpp
+++ b/src/paimon_storage/paimon_scan.cpp
@@ -237,9 +237,7 @@ public:
 	                     vector<column_t> column_ids)
 	    : read_column_ids(column_ids.begin(), column_ids.end()), global_state(gstate), bind_data(bind_data) {
 
-		if (NextSplit()) {
-			chunk = make_shared_ptr<ArrowArrayWrapper>();
-		}
+		NextSplit();
 	}
 
 	~PaimonScanLocalState() override {
@@ -393,6 +391,7 @@ static unique_ptr<LocalTableFunctionState> PaimonScanInitLocal(ExecutionContext 
 static void PaimonScan(ClientContext &context, TableFunctionInput &input, DataChunk &output) {
 	auto &global_state = input.global_state->Cast<PaimonScanGlobalState>();
 	auto &local_state = input.local_state->Cast<PaimonScanLocalState>();
+	auto current_chunk = make_shared_ptr<ArrowArrayWrapper>();
 
 	auto batch = local_state.NextBatch();
 	if (paimon::BatchReader::IsEofBatch(batch)) {
@@ -400,7 +399,10 @@ static void PaimonScan(ClientContext &context, TableFunctionInput &input, DataCh
 	}
 
 	auto &[c_array, c_schema] = batch;
-	auto current_chunk = make_shared_ptr<ArrowArrayWrapper>();
+	if (c_schema && c_schema->release) {
+		c_schema->release(c_schema.get());
+	}
+
 	current_chunk->arrow_array = *c_array;
 	c_array->release = nullptr;
 	local_state.chunk = current_chunk;
@@ -422,10 +424,6 @@ static void PaimonScan(ClientContext &context, TableFunctionInput &input, DataCh
 		                                         current_chunk->arrow_array.offset, -1);
 		ArrowToDuckDBConversion::ColumnArrowToDuckDB(output.data[col_idx], child_array, 0, array_state, output_size,
 		                                             arrow_type);
-	}
-
-	if (c_schema && c_schema->release) {
-		c_schema->release(c_schema.get());
 	}
 
 	output.Verify();


### PR DESCRIPTION
Release batch ArrowSchema immediately after fetching a non-EOF batch in paimon scan. The schema is not needed during row conversion, so eager release avoids keeping schema resources alive for the rest of the scan loop and keeps ownership handling clear.