### PR TITLE
feat(scan): add AND/OR conjunction support to predicate pushdown

### DIFF
--- a/src/paimon_storage/paimon_scan.cpp
+++ b/src/paimon_storage/paimon_scan.cpp
@@ -28,6 +28,7 @@
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 
@@ -104,10 +105,51 @@ static std::shared_ptr<paimon::Predicate> TryConvertComparison(const BoundCompar
 	}
 }
 
+// Forward declaration for mutual recursion with TryConvertConjunction.
+static std::shared_ptr<paimon::Predicate> TryConvertExpression(const Expression &expr, LogicalGet &get);
+
+static std::shared_ptr<paimon::Predicate> TryConvertConjunction(const BoundConjunctionExpression &conj,
+                                                                LogicalGet &get) {
+	std::vector<std::shared_ptr<paimon::Predicate>> predicates;
+
+	for (auto &child : conj.children) {
+		auto pred = TryConvertExpression(*child, get);
+		if (pred) {
+			predicates.push_back(std::move(pred));
+			continue;
+		}
+
+		D_ASSERT(!pred);
+
+		// For AND: skip unconvertible children (they stay in DuckDB's filter).
+		// For OR: the entire OR must be convertible, otherwise give up.
+		if (conj.type == ExpressionType::CONJUNCTION_OR) {
+			return nullptr;
+		}
+	}
+
+	// No predicate parsed.
+	if (predicates.empty()) {
+		return nullptr;
+	}
+
+	if (conj.type == ExpressionType::CONJUNCTION_AND) {
+		auto result = paimon::PredicateBuilder::And(predicates);
+		return result.ok() ? std::move(result.value()) : nullptr;
+	} else if (conj.type == ExpressionType::CONJUNCTION_OR) {
+		auto result = paimon::PredicateBuilder::Or(predicates);
+		return result.ok() ? std::move(result.value()) : nullptr;
+	}
+
+	return nullptr;
+}
+
 static std::shared_ptr<paimon::Predicate> TryConvertExpression(const Expression &expr, LogicalGet &get) {
 	switch (expr.GetExpressionClass()) {
 	case ExpressionClass::BOUND_COMPARISON:
 		return TryConvertComparison(expr.Cast<BoundComparisonExpression>(), get);
+	case ExpressionClass::BOUND_CONJUNCTION:
+		return TryConvertConjunction(expr.Cast<BoundConjunctionExpression>(), get);
 	default:
 		return nullptr;
 	}
@@ -120,11 +162,9 @@ static void PaimonPushdownFilter(ClientContext &context, LogicalGet &get, Functi
 
 	for (idx_t i = 0; i < filters.size(); i++) {
 		auto pred = TryConvertExpression(*filters[i], get);
-		if (!pred) {
-			continue;
+		if (pred) {
+			predicates.push_back(std::move(pred));
 		}
-
-		predicates.push_back(std::move(pred));
 
 		// We do not remove the filter from DuckDB's filter list here.
 		// Although the predicate has been pushed down to paimon-cpp,

--- a/test/sql/paimon_scan.test
+++ b/test/sql/paimon_scan.test
@@ -48,16 +48,3 @@ SELECT f3, f0 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc'
 31.0	Grace
 32.1	Henry
 33.2	Iris
-
-# predicate pushdown
-query II
-SELECT f3, f0 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 = 1;
-----
-11.0	Alice
-12.1	Bob
-13.2	Cathy
-
-# predicate pushdown
-query II
-SELECT f3, f0 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f3 = 16.0;
-----

--- a/test/sql/predicate_pushdown.test
+++ b/test/sql/predicate_pushdown.test
@@ -1,0 +1,83 @@
+# name: test/sql/predicate_pushdown.test
+# group: [sql]
+
+require paimon
+
+# predicate pushdown: equality
+query II
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 = 1;
+----
+Alice	1
+Bob	1
+Cathy	1
+
+# predicate pushdown: equality with no match
+query II
+SELECT f0, f3 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f3 = 16.0;
+----
+
+# predicate pushdown: AND with unconvertible child (partial pushdown)
+query II
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 = 1 AND length(f0) > 4;
+----
+Alice	1
+Cathy	1
+
+# predicate pushdown: AND narrows within a single file
+query III
+SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 = 1 AND f2 = 0;
+----
+Alice	1	0
+
+# predicate pushdown: OR with unconvertible child (cannot be pushed down)
+query II
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 = 1 OR length(f0) > 4;
+----
+Alice	1
+Bob	1
+Cathy	1
+David	2
+Frank	2
+Grace	3
+Henry	3
+
+# predicate pushdown: OR across files (filtered unrelated partition)
+query II
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 = 1 OR f1 = 3;
+----
+Alice	1
+Bob	1
+Cathy	1
+Grace	3
+Henry	3
+Iris	3
+
+# predicate pushdown: OR with no match on one branch (filtered impossible partition)
+query III
+SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 = 1 OR f2 = 3;
+----
+Alice	1	0
+Bob	1	1
+Cathy	1	2
+
+# predicate pushdown: OR with overlapping results (fetch all partitions)
+query III
+SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 = 1 OR f2 = 2;
+----
+Alice	1	0
+Bob	1	1
+Cathy	1	2
+Frank	2	2
+Iris	3	2
+
+# predicate pushdown: nested AND inside OR (filter unrelateds partition)
+query III
+SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE (f1 = 1 AND f2 = 0) OR (f1 = 3 AND f2 = 2);
+----
+Alice	1	0
+Iris	3	2
+
+# predicate pushdown: nested AND inside OR with no match (filter impossible partitions)
+query III
+SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE (f1 = 1 AND f2 = 3) OR (f1 = 3 AND f2 = 3);
+----


### PR DESCRIPTION
Extend predicate pushdown to handle conjunction expressions (AND/OR) in addition to simple comparisons. This enables more efficient filtering at the storage level:

- AND: partial pushdown supported - unconvertible children remain in DuckDB's filter list while convertible ones are pushed down
- OR: requires all children to be convertible, otherwise the entire OR expression stays in DuckDB

Add dedicated test file with comprehensive coverage for equality, AND, OR, and nested conjunction scenarios.