### PR TITLE
fix: redact key_id in paimon secret

### DIFF
--- a/src/paimon_extension.cpp
+++ b/src/paimon_extension.cpp
@@ -28,7 +28,6 @@
 
 #include "duckdb.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
-#include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/storage/storage_extension.hpp"
 
 namespace duckdb {
@@ -52,7 +51,7 @@ static unique_ptr<BaseSecret> CreatePaimonSecretFromConfig(ClientContext &contex
 	result->TrySetValue("key_id", input);
 	result->TrySetValue("secret", input);
 
-	result->redact_keys.insert("secret");
+	result->redact_keys = {"key_id", "secret"};
 
 	return std::move(result);
 }

--- a/src/paimon_storage/paimon_scan.cpp
+++ b/src/paimon_storage/paimon_scan.cpp
@@ -25,7 +25,6 @@
 #include "duckdb.hpp"
 #include "duckdb/common/constants.hpp"
 #include "duckdb/function/table/arrow.hpp"
-#include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"


### PR DESCRIPTION
Add key_id to the list of redacted keys alongside secret to prevent sensitive credential values from appearing in logs or error messages.