### PR TITLE
feat(scan): add IS NULL/IS NOT NULL to predicate pushdown

### DIFF
--- a/src/paimon_storage/paimon_scan.cpp
+++ b/src/paimon_storage/paimon_scan.cpp
@@ -112,6 +112,10 @@ static std::shared_ptr<paimon::Predicate> TryConvertOperator(const BoundOperator
 	case ExpressionType::COMPARE_NOT_IN:
 		D_ASSERT(op.children.size() >= 2);
 		break;
+	case ExpressionType::OPERATOR_IS_NULL:
+	case ExpressionType::OPERATOR_IS_NOT_NULL:
+		D_ASSERT(op.children.size() == 1);
+		break;
 	default:
 		return nullptr;
 	}
@@ -129,6 +133,10 @@ static std::shared_ptr<paimon::Predicate> TryConvertOperator(const BoundOperator
 	auto &field_name = get.GetColumnName(col_idx);
 
 	switch (op.type) {
+	case ExpressionType::OPERATOR_IS_NULL:
+		return paimon::PredicateBuilder::IsNull(field_index, field_name, paimon_type);
+	case ExpressionType::OPERATOR_IS_NOT_NULL:
+		return paimon::PredicateBuilder::IsNotNull(field_index, field_name, paimon_type);
 	case ExpressionType::COMPARE_IN:
 	case ExpressionType::COMPARE_NOT_IN: {
 		// Collect literals from children[1..n].

--- a/test/sql/predicate_pushdown.test
+++ b/test/sql/predicate_pushdown.test
@@ -130,3 +130,49 @@ Bob	1	1
 Cathy	1	2
 Frank	2	2
 Iris	3	2
+
+# predicate pushdown: IS NULL (no nulls in test data, expect empty result)
+query II
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f0 IS NULL;
+----
+
+# predicate pushdown: IS NOT NULL (no nulls in test data, expect all rows)
+query II
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f0 IS NOT NULL;
+----
+Alice	1
+Bob	1
+Cathy	1
+David	2
+Eve	2
+Frank	2
+Grace	3
+Henry	3
+Iris	3
+
+# predicate pushdown: IS NULL on integer column
+query II
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 IS NULL;
+----
+
+# predicate pushdown: IS NOT NULL combined with AND
+query II
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f0 IS NOT NULL AND f1 = 1;
+----
+Alice	1
+Bob	1
+Cathy	1
+
+# predicate pushdown: IS NOT NULL combined with OR
+query II
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f0 IS NOT NULL OR f1 = 1;
+----
+Alice	1
+Bob	1
+Cathy	1
+David	2
+Eve	2
+Frank	2
+Grace	3
+Henry	3
+Iris	3


### PR DESCRIPTION
Add support for IS NULL and IS NOT NULL operators in predicate pushdown, allowing these conditions to be pushed down to Paimon for more efficient filtering.