### PR TITLE
feat(scan): add comparison operators to predicate pushdown

### DIFF
--- a/src/paimon_storage/paimon_scan.cpp
+++ b/src/paimon_storage/paimon_scan.cpp
@@ -60,9 +60,14 @@ public:
 };
 
 static std::shared_ptr<paimon::Predicate> TryConvertComparison(const BoundComparisonExpression &comp, LogicalGet &get) {
-	// early exit
+	// early exit: only handle comparison types supported by paimon-cpp
 	switch (comp.type) {
 	case ExpressionType::COMPARE_EQUAL:
+	case ExpressionType::COMPARE_NOTEQUAL:
+	case ExpressionType::COMPARE_LESSTHAN:
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+	case ExpressionType::COMPARE_GREATERTHAN:
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
 		break;
 	default:
 		return nullptr;
@@ -96,10 +101,22 @@ static std::shared_ptr<paimon::Predicate> TryConvertComparison(const BoundCompar
 		return nullptr;
 	}
 
+	auto field_index = col_idx.GetPrimaryIndex();
+	auto &field_name = get.GetColumnName(col_idx);
+
 	switch (comparison_type) {
 	case ExpressionType::COMPARE_EQUAL:
-		return paimon::PredicateBuilder::Equal(col_idx.GetPrimaryIndex(), get.GetColumnName(col_idx), paimon_type,
-		                                       literal.value());
+		return paimon::PredicateBuilder::Equal(field_index, field_name, paimon_type, literal.value());
+	case ExpressionType::COMPARE_NOTEQUAL:
+		return paimon::PredicateBuilder::NotEqual(field_index, field_name, paimon_type, literal.value());
+	case ExpressionType::COMPARE_LESSTHAN:
+		return paimon::PredicateBuilder::LessThan(field_index, field_name, paimon_type, literal.value());
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		return paimon::PredicateBuilder::LessOrEqual(field_index, field_name, paimon_type, literal.value());
+	case ExpressionType::COMPARE_GREATERTHAN:
+		return paimon::PredicateBuilder::GreaterThan(field_index, field_name, paimon_type, literal.value());
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		return paimon::PredicateBuilder::GreaterOrEqual(field_index, field_name, paimon_type, literal.value());
 	default:
 		return nullptr;
 	}

--- a/test/sql/predicate_pushdown.test
+++ b/test/sql/predicate_pushdown.test
@@ -131,6 +131,84 @@ Cathy	1	2
 Frank	2	2
 Iris	3	2
 
+# predicate pushdown: not equal
+query II
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 != 2;
+----
+Alice	1
+Bob	1
+Cathy	1
+Grace	3
+Henry	3
+Iris	3
+
+# predicate pushdown: less than
+query II
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 < 2;
+----
+Alice	1
+Bob	1
+Cathy	1
+
+# predicate pushdown: less than or equal
+query II
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 <= 2;
+----
+Alice	1
+Bob	1
+Cathy	1
+David	2
+Eve	2
+Frank	2
+
+# predicate pushdown: greater than
+query II
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 > 2;
+----
+Grace	3
+Henry	3
+Iris	3
+
+# predicate pushdown: greater than or equal
+query II
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 >= 2;
+----
+David	2
+Eve	2
+Frank	2
+Grace	3
+Henry	3
+Iris	3
+
+# predicate pushdown: range filter with less than and greater than combined
+query III
+SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 >= 2 AND f2 < 2;
+----
+David	2	0
+Eve	2	1
+Grace	3	0
+Henry	3	1
+
+# predicate pushdown: not equal combined with OR
+query III
+SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 != 2 OR f2 = 0;
+----
+Alice	1	0
+Bob	1	1
+Cathy	1	2
+David	2	0
+Grace	3	0
+Henry	3	1
+Iris	3	2
+
+# predicate pushdown: constant on left side (flipped comparison)
+query II
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE 2 < f1;
+----
+Grace	3
+Henry	3
+Iris	3
+
 # predicate pushdown: IS NULL (no nulls in test data, expect empty result)
 query II
 SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f0 IS NULL;


### PR DESCRIPTION
Extend predicate pushdown to support NOT EQUAL, LESS THAN, LESS OR EQUAL, GREATER THAN, and GREATER OR EQUAL comparison operators in addition to the existing EQUAL support.