### PR TITLE
feat(snapshot): add paimon_snapshots table function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ set(EXTENSION_SOURCES
   src/paimon_extension.cpp
   src/paimon_functions.cpp
   src/paimon_storage/paimon_scan.cpp
+  src/paimon_storage/paimon_snapshots.cpp
   src/paimon_storage/paimon_catalog.cpp
   src/paimon_storage/paimon_schema_entry.cpp
   src/paimon_storage/paimon_schema_set.cpp

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This extension is built on top of [paimon-cpp](https://github.com/alibaba/paimon
 - Multiple file format support (Parquet data files, ORC manifest files)
 - Catalog ATTACH support
 - DuckDB Secret-based OSS credential management
+- Snapshot history inspection
 
 ## Use Cases
 
@@ -118,6 +119,29 @@ ATTACH 'oss://my-bucket/warehouse' AS paimon_lake (TYPE paimon);
 
 SHOW ALL TABLES;
 DESCRIBE paimon_lake.sales_db.orders;
+```
+
+#### Inspect Snapshot History
+
+Use `paimon_snapshots` to list all snapshots of a Paimon table — useful for auditing commit history, diagnosing data issues, or identifying a snapshot ID for time-travel queries.
+
+```sql
+-- Using a full filesystem path
+SELECT snapshot_id, commit_kind, commit_time, total_record_count
+FROM paimon_snapshots('./warehouse/mydb.db/orders')
+ORDER BY snapshot_id;
+┌─────────────┬─────────────┬─────────────────────────┬────────────────────┐
+│ snapshot_id │ commit_kind │       commit_time        │ total_record_count │
+│    int64    │   varchar   │        timestamp         │       int64        │
+├─────────────┼─────────────┼─────────────────────────┼────────────────────┤
+│           1 │ APPEND      │ 2026-01-15 08:00:01.234  │                  3 │
+│           2 │ APPEND      │ 2026-01-15 08:00:02.456  │                  6 │
+│           3 │ COMPACT     │ 2026-01-15 08:00:10.789  │                  6 │
+└─────────────┴─────────────┴─────────────────────────┴────────────────────┘
+
+-- Alternatively, pass warehouse / database / table as separate arguments
+SELECT snapshot_id, commit_kind, total_record_count
+FROM paimon_snapshots('oss://my-bucket/warehouse', 'mydb', 'orders');
 ```
 
 ### Running the Tests

--- a/src/include/paimon_functions.hpp
+++ b/src/include/paimon_functions.hpp
@@ -28,12 +28,21 @@
 
 namespace duckdb {
 
+struct PaimonTablePath {
+	string warehouse;
+	string dbname;
+	string tablename;
+
+	static PaimonTablePath Parse(const vector<Value> &inputs);
+};
+
 class PaimonFunctions {
 public:
 	static vector<TableFunctionSet> GetTableFunctions();
 
 private:
 	static TableFunctionSet GetPaimonScanFunction();
+	static TableFunctionSet GetPaimonSnapshotsFunction();
 };
 
 } // namespace duckdb

--- a/src/paimon_functions.cpp
+++ b/src/paimon_functions.cpp
@@ -24,12 +24,53 @@
 
 #include "paimon_functions.hpp"
 
+#include "paimon/catalog/catalog.h"
+
 namespace duckdb {
+
+PaimonTablePath PaimonTablePath::Parse(const vector<Value> &inputs) {
+	PaimonTablePath result;
+
+	if (inputs.empty()) {
+		throw InvalidInputException("warehouse path is necessary");
+	}
+
+	if (inputs.size() > 1) {
+		result.warehouse = inputs[0].ToString();
+		result.dbname = inputs[1].ToString();
+		result.tablename = inputs[2].ToString();
+	} else {
+		auto whole_path = inputs[0].ToString();
+		auto last_slash = whole_path.find_last_of('/');
+
+		if (last_slash == string::npos) {
+			throw InvalidInputException("Invalid database path format: missing '/'");
+		}
+
+		result.tablename = whole_path.substr(last_slash + 1);
+
+		whole_path = whole_path.substr(0, last_slash);
+		last_slash = whole_path.find_last_of('/');
+
+		string dbname_raw = whole_path.substr(last_slash + 1);
+		string dbsuffix(paimon::Catalog::DB_SUFFIX);
+
+		if (!StringUtil::EndsWith(dbname_raw, dbsuffix)) {
+			throw InvalidInputException("Invalid database path format");
+		}
+
+		result.dbname = dbname_raw.substr(0, dbname_raw.size() - dbsuffix.size());
+		result.warehouse = whole_path.substr(0, last_slash);
+	}
+
+	return result;
+}
 
 vector<TableFunctionSet> PaimonFunctions::GetTableFunctions() {
 	vector<TableFunctionSet> functions;
 
 	functions.push_back(GetPaimonScanFunction());
+	functions.push_back(GetPaimonSnapshotsFunction());
 
 	return functions;
 }

--- a/src/paimon_storage/paimon_scan.cpp
+++ b/src/paimon_storage/paimon_scan.cpp
@@ -50,9 +50,7 @@ namespace duckdb {
 
 struct PaimonScanBindData : public TableFunctionData {
 public:
-	string warehouse;
-	string dbname;
-	string tablename;
+	PaimonTablePath path;
 
 	map<string, string> paimon_options;
 
@@ -431,47 +429,14 @@ static unique_ptr<FunctionData> PaimonScanBind(ClientContext &context, TableFunc
                                                vector<LogicalType> &return_types, vector<string> &names) {
 	auto bind_data = make_uniq<PaimonScanBindData>();
 
-	string warehouse;
-	string dbname;
-
-	if (input.inputs.empty()) {
-		throw InvalidInputException("warehouse path is necessary");
-	}
-
-	if (input.inputs.size() > 1) {
-		bind_data->warehouse = input.inputs[0].ToString();
-		bind_data->dbname = input.inputs[1].ToString();
-		bind_data->tablename = input.inputs[2].ToString();
-	} else {
-		auto whole_path = input.inputs[0].ToString();
-		auto last_slash = whole_path.find_last_of('/');
-
-		if (last_slash == string::npos) {
-			throw InvalidInputException("Invalid database path format: missing '/'");
-		}
-
-		bind_data->tablename = whole_path.substr(last_slash + 1);
-
-		whole_path = whole_path.substr(0, last_slash);
-		last_slash = whole_path.find_last_of('/');
-
-		string dbname_raw = whole_path.substr(last_slash + 1);
-		string dbsuffix(paimon::Catalog::DB_SUFFIX);
-
-		if (!StringUtil::EndsWith(dbname_raw, dbsuffix)) {
-			throw InvalidInputException("Invalid database path format");
-		}
-
-		bind_data->dbname = dbname_raw.substr(0, dbname_raw.size() - dbsuffix.size());
-		bind_data->warehouse = whole_path.substr(0, last_slash);
-	}
+	auto path = PaimonTablePath::Parse(input.inputs);
+	bind_data->path = path;
 
 	unordered_map<string, Value> scan_options(input.named_parameters.begin(), input.named_parameters.end());
-	bind_data->paimon_options = PaimonCatalog::GetPaimonOptions(context, bind_data->warehouse, scan_options);
-	auto paimon_catalog = PaimonCatalog::CreatePaimonCatalog(context, bind_data->warehouse, scan_options);
+	bind_data->paimon_options = PaimonCatalog::GetPaimonOptions(context, path.warehouse, scan_options);
+	auto paimon_catalog = PaimonCatalog::CreatePaimonCatalog(context, path.warehouse, scan_options);
 
-	auto table_schema_result =
-	    paimon_catalog->LoadTableSchema(paimon::Identifier(bind_data->dbname, bind_data->tablename));
+	auto table_schema_result = paimon_catalog->LoadTableSchema(paimon::Identifier(path.dbname, path.tablename));
 	if (!table_schema_result.ok()) {
 		throw IOException(table_schema_result.status().ToString());
 	}
@@ -645,7 +610,7 @@ static unique_ptr<GlobalTableFunctionState> PaimonScanInitGlobal(ClientContext &
 		state->paimon_predicates = pred_res.value();
 	}
 
-	auto path = bind.warehouse + "/" + bind.dbname + paimon::Catalog::DB_SUFFIX + "/" + bind.tablename;
+	auto path = bind.path.warehouse + "/" + bind.path.dbname + paimon::Catalog::DB_SUFFIX + "/" + bind.path.tablename;
 
 	// construct the scanner
 	paimon::ScanContextBuilder scan_context_builder(path);

--- a/src/paimon_storage/paimon_snapshots.cpp
+++ b/src/paimon_storage/paimon_snapshots.cpp
@@ -1,0 +1,127 @@
+/*-------------------------------------------------------------------------
+ *
+ * paimon_snapshots.cpp
+ *
+ * Copyright (c) 2026, Alibaba Group Holding Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * IDENTIFICATION
+ *      src/paimon_storage/paimon_snapshots.cpp
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "duckdb.hpp"
+
+#include "paimon_catalog.hpp"
+#include "paimon_functions.hpp"
+
+#include "paimon/catalog/identifier.h"
+#include "paimon/snapshot/snapshot_info.h"
+
+namespace duckdb {
+
+struct PaimonSnapshotsBindData : public TableFunctionData {
+	PaimonTablePath path;
+	unordered_map<string, Value> input_options;
+};
+
+struct PaimonSnapshotsGlobalState : public GlobalTableFunctionState {
+	vector<paimon::SnapshotInfo> snapshots;
+	idx_t current_row = 0;
+
+	idx_t MaxThreads() const override {
+		return 1;
+	}
+};
+
+static unique_ptr<FunctionData> PaimonSnapshotsBind(ClientContext &context, TableFunctionBindInput &input,
+                                                    vector<LogicalType> &return_types, vector<string> &names) {
+	auto bind_data = make_uniq<PaimonSnapshotsBindData>();
+
+	bind_data->path = PaimonTablePath::Parse(input.inputs);
+	bind_data->input_options =
+	    unordered_map<string, Value>(input.named_parameters.begin(), input.named_parameters.end());
+
+	names = {"snapshot_id", "schema_id",          "commit_user",        "commit_kind",
+	         "commit_time", "total_record_count", "delta_record_count", "watermark"};
+
+	return_types = {LogicalType::BIGINT,    LogicalType::BIGINT, LogicalType::VARCHAR, LogicalType::VARCHAR,
+	                LogicalType::TIMESTAMP, LogicalType::BIGINT, LogicalType::BIGINT,  LogicalType::BIGINT};
+
+	return std::move(bind_data);
+}
+
+static unique_ptr<GlobalTableFunctionState> PaimonSnapshotsInitGlobal(ClientContext &context,
+                                                                      TableFunctionInitInput &input) {
+	auto &bind = input.bind_data->Cast<PaimonSnapshotsBindData>();
+	auto state = make_uniq<PaimonSnapshotsGlobalState>();
+
+	auto paimon_catalog = PaimonCatalog::CreatePaimonCatalog(context, bind.path.warehouse, bind.input_options);
+
+	paimon::Identifier identifier(bind.path.dbname, bind.path.tablename);
+	auto result = paimon_catalog->ListSnapshots(identifier);
+	if (!result.ok()) {
+		throw IOException(result.status().ToString());
+	}
+	state->snapshots = std::move(result).value();
+
+	return std::move(state);
+}
+
+static void PaimonSnapshotsExecute(ClientContext &context, TableFunctionInput &input, DataChunk &output) {
+	auto &state = input.global_state->Cast<PaimonSnapshotsGlobalState>();
+
+	idx_t count = 0;
+	while (state.current_row < state.snapshots.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &snap = state.snapshots[state.current_row];
+
+		output.SetValue(0, count, Value::BIGINT(snap.snapshot_id));
+		output.SetValue(1, count, Value::BIGINT(snap.schema_id));
+		output.SetValue(2, count, Value(snap.commit_user));
+		output.SetValue(3, count, Value(paimon::SnapshotInfo::CommitKindToString(snap.commit_kind)));
+
+		// timeMillis is epoch ms; DuckDB timestamp_t is epoch us
+		timestamp_t ts;
+		ts.value = snap.time_millis * 1000;
+		output.SetValue(4, count, Value::TIMESTAMP(ts));
+
+		output.SetValue(5, count, snap.total_record_count ? Value::BIGINT(snap.total_record_count.value()) : Value());
+		output.SetValue(6, count, snap.delta_record_count ? Value::BIGINT(snap.delta_record_count.value()) : Value());
+		output.SetValue(7, count, snap.watermark ? Value::BIGINT(snap.watermark.value()) : Value());
+
+		state.current_row++;
+		count++;
+	}
+
+	output.SetCardinality(count);
+}
+
+TableFunctionSet PaimonFunctions::GetPaimonSnapshotsFunction() {
+	TableFunctionSet function_set("paimon_snapshots");
+
+	auto fun = TableFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR}, PaimonSnapshotsExecute,
+	                         PaimonSnapshotsBind, PaimonSnapshotsInitGlobal);
+	fun.named_parameters["manifest_format"] = LogicalType::VARCHAR;
+	function_set.AddFunction(fun);
+
+	auto fun_fullpath =
+	    TableFunction({LogicalType::VARCHAR}, PaimonSnapshotsExecute, PaimonSnapshotsBind, PaimonSnapshotsInitGlobal);
+	fun_fullpath.named_parameters["manifest_format"] = LogicalType::VARCHAR;
+	function_set.AddFunction(fun_fullpath);
+
+	return function_set;
+}
+
+} // namespace duckdb

--- a/test/sql/paimon_snapshots.test
+++ b/test/sql/paimon_snapshots.test
@@ -1,0 +1,30 @@
+# name: test/sql/paimon_snapshots.test
+# group: [sql]
+
+require paimon
+
+# full-path form: verify row count
+query I
+SELECT count(*) FROM paimon_snapshots('./data/testdb.db/testtbl');
+----
+3
+
+# 3-arg form: verify key columns across all snapshots
+query IIIII
+SELECT snapshot_id, schema_id, commit_kind, total_record_count, delta_record_count
+FROM paimon_snapshots('./data', 'testdb', 'testtbl')
+ORDER BY snapshot_id;
+----
+1	0	APPEND	3	3
+2	0	APPEND	6	3
+3	0	APPEND	9	3
+
+# optional nullable column is NULL when absent
+query I
+SELECT watermark
+FROM paimon_snapshots('./data/testdb.db/testtbl')
+ORDER BY snapshot_id;
+----
+NULL
+NULL
+NULL


### PR DESCRIPTION
## Summary
- Add `paimon_snapshots` table function to expose full snapshot history of a Paimon table
- Extract shared path-parsing logic into a reusable `PaimonTablePath` struct, embed it in both scan and snapshot bind data
- Defer catalog option resolution from bind to init, letting `CreatePaimonCatalog` handle it

## Test plan
- [x] `test/sql/paimon_snapshots.test` covers full-path and 3-arg forms, key columns, and nullable columns

🤖 Generated with [Claude Code](https://claude.ai/claude-code)