### PR TITLE
feat(scan): auto-detect manifest and data file formats

### DIFF
--- a/src/include/paimon_catalog.hpp
+++ b/src/include/paimon_catalog.hpp
@@ -47,9 +47,9 @@ public:
 	                                                               AttachedDatabase &db, Catalog &catalog);
 
 	static map<string, string> GetPaimonOptions(ClientContext &context, const string &path,
-	                                            const unordered_map<string, Value> &attached_options);
+	                                            const unordered_map<string, Value> &input_options);
 	static unique_ptr<paimon::Catalog> CreatePaimonCatalog(ClientContext &context, const string &path,
-	                                                       const unordered_map<string, Value> &attached_options);
+	                                                       const unordered_map<string, Value> &input_options);
 
 	// catalog APIs
 	void Initialize(bool load_builtin) override;

--- a/src/paimon_storage/paimon_catalog.cpp
+++ b/src/paimon_storage/paimon_catalog.cpp
@@ -71,16 +71,26 @@ static string GetValidatedFormatOption(const unordered_map<string, Value> &attac
 }
 
 map<string, string> PaimonCatalog::GetPaimonOptions(ClientContext &context, const string &path,
-                                                    const unordered_map<string, Value> &attached_options) {
-	// default options
+                                                    const unordered_map<string, Value> &input_options) {
+	// Format options are only injected when the user explicitly provides them.
+	// Otherwise paimon-cpp resolves the format from the table schema's own
+	// options (with defaults: manifest.format=avro, file.format=parquet).
 	static const vector<string> supported_manifest_formats = {"avro", "orc", "parquet"};
 	static const vector<string> supported_file_formats = {"avro", "blob", "orc", "parquet"};
 
-	map<string, string> paimon_options = {
-	    {paimon::Options::MANIFEST_FORMAT,
-	     GetValidatedFormatOption(attached_options, "manifest_format", "avro", supported_manifest_formats)},
-	    {paimon::Options::FILE_FORMAT,
-	     GetValidatedFormatOption(attached_options, "file_format", "parquet", supported_file_formats)}};
+	map<string, string> paimon_options;
+
+	auto manifest_fmt = TryGetPaimonOptionValue(input_options, "manifest_format");
+	if (manifest_fmt.has_value()) {
+		paimon_options[paimon::Options::MANIFEST_FORMAT] =
+		    GetValidatedFormatOption(input_options, "manifest_format", "", supported_manifest_formats);
+	}
+
+	auto file_fmt = TryGetPaimonOptionValue(input_options, "file_format");
+	if (file_fmt.has_value()) {
+		paimon_options[paimon::Options::FILE_FORMAT] =
+		    GetValidatedFormatOption(input_options, "file_format", "", supported_file_formats);
+	}
 
 	// secret loading
 	auto &secret_manager = SecretManager::Get(context);
@@ -122,8 +132,8 @@ map<string, string> PaimonCatalog::GetPaimonOptions(ClientContext &context, cons
 }
 
 unique_ptr<paimon::Catalog> PaimonCatalog::CreatePaimonCatalog(ClientContext &context, const string &path,
-                                                               const unordered_map<string, Value> &attached_options) {
-	auto paimon_options = PaimonCatalog::GetPaimonOptions(context, path, attached_options);
+                                                               const unordered_map<string, Value> &input_options) {
+	auto paimon_options = PaimonCatalog::GetPaimonOptions(context, path, input_options);
 
 	auto result = paimon::Catalog::Create(path, paimon_options);
 	if (!result.ok()) {

--- a/src/paimon_storage/paimon_scan.cpp
+++ b/src/paimon_storage/paimon_scan.cpp
@@ -694,16 +694,16 @@ TableFunctionSet PaimonFunctions::GetPaimonScanFunction() {
 
 	auto fun = TableFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR}, PaimonScan,
 	                         PaimonScanBind, PaimonScanInitGlobal);
-	fun.named_parameters["manifest_format"] = LogicalType::VARCHAR;
-	fun.named_parameters["file_format"] = LogicalType::VARCHAR;
+	fun.named_parameters["manifest_format"] = LogicalType::VARCHAR; // deprecated: auto-detected from table schema
+	fun.named_parameters["file_format"] = LogicalType::VARCHAR;     // deprecated: auto-detected from table schema
 	fun.init_local = PaimonScanInitLocal;
 	fun.projection_pushdown = true;
 	fun.pushdown_complex_filter = PaimonPushdownFilter;
 	function_set.AddFunction(fun);
 
 	auto fun_fullpath = TableFunction({LogicalType::VARCHAR}, PaimonScan, PaimonScanBind, PaimonScanInitGlobal);
-	fun_fullpath.named_parameters["manifest_format"] = LogicalType::VARCHAR;
-	fun_fullpath.named_parameters["file_format"] = LogicalType::VARCHAR;
+	fun_fullpath.named_parameters["manifest_format"] = LogicalType::VARCHAR; // deprecated
+	fun_fullpath.named_parameters["file_format"] = LogicalType::VARCHAR;     // deprecated
 	fun_fullpath.init_local = PaimonScanInitLocal;
 	fun_fullpath.projection_pushdown = true;
 	fun_fullpath.pushdown_complex_filter = PaimonPushdownFilter;

--- a/src/paimon_storage/paimon_snapshots.cpp
+++ b/src/paimon_storage/paimon_snapshots.cpp
@@ -113,12 +113,12 @@ TableFunctionSet PaimonFunctions::GetPaimonSnapshotsFunction() {
 
 	auto fun = TableFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR}, PaimonSnapshotsExecute,
 	                         PaimonSnapshotsBind, PaimonSnapshotsInitGlobal);
-	fun.named_parameters["manifest_format"] = LogicalType::VARCHAR;
+	fun.named_parameters["manifest_format"] = LogicalType::VARCHAR; // deprecated: auto-detected from table schema
 	function_set.AddFunction(fun);
 
 	auto fun_fullpath =
 	    TableFunction({LogicalType::VARCHAR}, PaimonSnapshotsExecute, PaimonSnapshotsBind, PaimonSnapshotsInitGlobal);
-	fun_fullpath.named_parameters["manifest_format"] = LogicalType::VARCHAR;
+	fun_fullpath.named_parameters["manifest_format"] = LogicalType::VARCHAR; // deprecated
 	function_set.AddFunction(fun_fullpath);
 
 	return function_set;

--- a/test/sql/decimal.test
+++ b/test/sql/decimal.test
@@ -23,18 +23,18 @@ require paimon
 
 # equality
 query II
-SELECT col_string, col_decimal FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_decimal = 100.50;
+SELECT col_string, col_decimal FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_decimal = 100.50;
 ----
 Alice	100.50
 
 # equality with no match
 query II
-SELECT col_string, col_decimal FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_decimal = 777.77;
+SELECT col_string, col_decimal FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_decimal = 777.77;
 ----
 
 # not equal
 query I
-SELECT col_string FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_decimal != 999.99 ORDER BY col_string;
+SELECT col_string FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_decimal != 999.99 ORDER BY col_string;
 ----
 Alice
 Bob
@@ -47,7 +47,7 @@ Iris
 
 # greater than
 query II
-SELECT col_string, col_decimal FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_decimal > 200.00 ORDER BY col_string;
+SELECT col_string, col_decimal FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_decimal > 200.00 ORDER BY col_string;
 ----
 Bob	200.75
 Cathy	350.00
@@ -56,7 +56,7 @@ Henry	500.00
 
 # less than
 query II
-SELECT col_string, col_decimal FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_decimal < 100.00 ORDER BY col_string;
+SELECT col_string, col_decimal FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_decimal < 100.00 ORDER BY col_string;
 ----
 David	50.25
 Grace	0.01
@@ -64,14 +64,14 @@ Iris	75.80
 
 # greater than or equal
 query II
-SELECT col_string, col_decimal FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_decimal >= 500.00 ORDER BY col_string;
+SELECT col_string, col_decimal FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_decimal >= 500.00 ORDER BY col_string;
 ----
 Eve	999.99
 Henry	500.00
 
 # less than or equal
 query II
-SELECT col_string, col_decimal FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_decimal <= 100.50 ORDER BY col_string;
+SELECT col_string, col_decimal FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_decimal <= 100.50 ORDER BY col_string;
 ----
 Alice	100.50
 David	50.25
@@ -80,7 +80,7 @@ Iris	75.80
 
 # BETWEEN
 query II
-SELECT col_string, col_decimal FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_decimal BETWEEN 50.25 AND 200.75 ORDER BY col_string;
+SELECT col_string, col_decimal FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_decimal BETWEEN 50.25 AND 200.75 ORDER BY col_string;
 ----
 Alice	100.50
 Bob	200.75
@@ -90,7 +90,7 @@ Iris	75.80
 
 # IN list
 query II
-SELECT col_string, col_decimal FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_decimal IN (100.50, 999.99, 0.01) ORDER BY col_string;
+SELECT col_string, col_decimal FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_decimal IN (100.50, 999.99, 0.01) ORDER BY col_string;
 ----
 Alice	100.50
 Eve	999.99
@@ -98,7 +98,7 @@ Grace	0.01
 
 # NOT IN
 query II
-SELECT col_string, col_decimal FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_decimal NOT IN (100.50, 200.75, 350.00, 50.25, 999.99, 123.45) ORDER BY col_string;
+SELECT col_string, col_decimal FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_decimal NOT IN (100.50, 200.75, 350.00, 50.25, 999.99, 123.45) ORDER BY col_string;
 ----
 Grace	0.01
 Henry	500.00
@@ -106,13 +106,13 @@ Iris	75.80
 
 # IS NULL (row 10 has NULL decimal)
 query I
-SELECT col_string FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_decimal IS NULL;
+SELECT col_string FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_decimal IS NULL;
 ----
 NULL
 
 # IS NOT NULL (rows 1-9 have non-NULL decimals)
 query I
-SELECT col_string FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_decimal IS NOT NULL ORDER BY col_string;
+SELECT col_string FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_decimal IS NOT NULL ORDER BY col_string;
 ----
 Alice
 Bob
@@ -126,14 +126,14 @@ Iris
 
 # constant on left side (flipped comparison)
 query II
-SELECT col_string, col_decimal FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE 500.00 <= col_decimal ORDER BY col_string;
+SELECT col_string, col_decimal FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE 500.00 <= col_decimal ORDER BY col_string;
 ----
 Eve	999.99
 Henry	500.00
 
 # combined: decimal AND integer
 query III
-SELECT col_string, col_decimal, col_int FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_decimal > 100.00 AND col_int > 0 ORDER BY col_string;
+SELECT col_string, col_decimal, col_int FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_decimal > 100.00 AND col_int > 0 ORDER BY col_string;
 ----
 Alice	100.50	1000
 Bob	200.75	2000
@@ -143,14 +143,14 @@ Henry	500.00	54321
 
 # combined: decimal AND timestamp
 query III
-SELECT col_string, col_decimal, col_timestamp FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_decimal >= 100.00 AND col_timestamp < TIMESTAMP '2025-06-01 00:00:00' ORDER BY col_string;
+SELECT col_string, col_decimal, col_timestamp FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_decimal >= 100.00 AND col_timestamp < TIMESTAMP '2025-06-01 00:00:00' ORDER BY col_string;
 ----
 Alice	100.50	2025-01-15 10:30:00
 Bob	200.75	2025-03-20 14:15:30
 
 # combined: decimal OR string
 query II
-SELECT col_string, col_decimal FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_decimal = 999.99 OR col_string = 'Grace';
+SELECT col_string, col_decimal FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_decimal = 999.99 OR col_string = 'Grace';
 ----
 Eve	999.99
 Grace	0.01

--- a/test/sql/paimon_catalog.test
+++ b/test/sql/paimon_catalog.test
@@ -15,7 +15,7 @@ statement ok
 DETACH paimon_default;
 
 statement ok
-ATTACH './data' AS paimon_lake (TYPE paimon, manifest_format 'avro');
+ATTACH './data' AS paimon_lake (TYPE paimon);
 
 query I
 SELECT count(*) FROM paimon_lake.avro_manifest.testtbl;

--- a/test/sql/paimon_scan.test
+++ b/test/sql/paimon_scan.test
@@ -4,7 +4,7 @@
 require paimon
 
 query IIII
-SELECT * FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc');
+SELECT * FROM paimon_scan('./data/testdb.db/testtbl');
 ----
 Alice	1	0	11.0
 Bob	1	1	12.1
@@ -23,7 +23,7 @@ SELECT count(*) FROM paimon_scan('./data/avro_manifest.db/testtbl');
 
 # projection pushdown
 query I
-SELECT f0 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc');
+SELECT f0 FROM paimon_scan('./data/testdb.db/testtbl');
 ----
 Alice
 Bob
@@ -37,7 +37,7 @@ Iris
 
 # projection pushdown
 query II
-SELECT f3, f0 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc');
+SELECT f3, f0 FROM paimon_scan('./data/testdb.db/testtbl');
 ----
 11.0	Alice
 12.1	Bob

--- a/test/sql/predicate_pushdown.test
+++ b/test/sql/predicate_pushdown.test
@@ -5,7 +5,7 @@ require paimon
 
 # predicate pushdown: equality
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 = 1;
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 = 1;
 ----
 Alice	1
 Bob	1
@@ -13,25 +13,25 @@ Cathy	1
 
 # predicate pushdown: equality with no match
 query II
-SELECT f0, f3 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f3 = 16.0;
+SELECT f0, f3 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f3 = 16.0;
 ----
 
 # predicate pushdown: AND with unconvertible child (partial pushdown)
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 = 1 AND length(f0) > 4;
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 = 1 AND length(f0) > 4;
 ----
 Alice	1
 Cathy	1
 
 # predicate pushdown: AND narrows within a single file
 query III
-SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 = 1 AND f2 = 0;
+SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 = 1 AND f2 = 0;
 ----
 Alice	1	0
 
 # predicate pushdown: OR with unconvertible child (cannot be pushed down)
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 = 1 OR length(f0) > 4;
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 = 1 OR length(f0) > 4;
 ----
 Alice	1
 Bob	1
@@ -43,7 +43,7 @@ Henry	3
 
 # predicate pushdown: OR across files (filtered unrelated partition)
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 = 1 OR f1 = 3;
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 = 1 OR f1 = 3;
 ----
 Alice	1
 Bob	1
@@ -54,7 +54,7 @@ Iris	3
 
 # predicate pushdown: OR with no match on one branch (filtered impossible partition)
 query III
-SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 = 1 OR f2 = 3;
+SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 = 1 OR f2 = 3;
 ----
 Alice	1	0
 Bob	1	1
@@ -62,7 +62,7 @@ Cathy	1	2
 
 # predicate pushdown: OR with overlapping results (fetch all partitions)
 query III
-SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 = 1 OR f2 = 2;
+SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 = 1 OR f2 = 2;
 ----
 Alice	1	0
 Bob	1	1
@@ -72,19 +72,19 @@ Iris	3	2
 
 # predicate pushdown: nested AND inside OR (filter unrelateds partition)
 query III
-SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE (f1 = 1 AND f2 = 0) OR (f1 = 3 AND f2 = 2);
+SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl') WHERE (f1 = 1 AND f2 = 0) OR (f1 = 3 AND f2 = 2);
 ----
 Alice	1	0
 Iris	3	2
 
 # predicate pushdown: nested AND inside OR with no match (filter impossible partitions)
 query III
-SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE (f1 = 1 AND f2 = 3) OR (f1 = 3 AND f2 = 3);
+SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl') WHERE (f1 = 1 AND f2 = 3) OR (f1 = 3 AND f2 = 3);
 ----
 
 # predicate pushdown: IN
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 IN (1, 3);
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 IN (1, 3);
 ----
 Alice	1
 Bob	1
@@ -95,7 +95,7 @@ Iris	3
 
 # predicate pushdown: IN with single value
 query II
-SELECT f0, f2 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f2 IN (0);
+SELECT f0, f2 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f2 IN (0);
 ----
 Alice	0
 David	0
@@ -103,12 +103,12 @@ Grace	0
 
 # predicate pushdown: IN with no match
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 IN (4, 5);
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 IN (4, 5);
 ----
 
 # predicate pushdown: NOT IN
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 NOT IN (1, 3);
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 NOT IN (1, 3);
 ----
 David	2
 Eve	2
@@ -116,14 +116,14 @@ Frank	2
 
 # predicate pushdown: IN combined with AND
 query III
-SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 IN (1, 2) AND f2 = 0;
+SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 IN (1, 2) AND f2 = 0;
 ----
 Alice	1	0
 David	2	0
 
 # predicate pushdown: IN combined with OR
 query III
-SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 IN (1) OR f2 IN (2);
+SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 IN (1) OR f2 IN (2);
 ----
 Alice	1	0
 Bob	1	1
@@ -133,7 +133,7 @@ Iris	3	2
 
 # predicate pushdown: not equal
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 != 2;
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 != 2;
 ----
 Alice	1
 Bob	1
@@ -144,7 +144,7 @@ Iris	3
 
 # predicate pushdown: less than
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 < 2;
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 < 2;
 ----
 Alice	1
 Bob	1
@@ -152,7 +152,7 @@ Cathy	1
 
 # predicate pushdown: less than or equal
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 <= 2;
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 <= 2;
 ----
 Alice	1
 Bob	1
@@ -163,7 +163,7 @@ Frank	2
 
 # predicate pushdown: greater than
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 > 2;
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 > 2;
 ----
 Grace	3
 Henry	3
@@ -171,7 +171,7 @@ Iris	3
 
 # predicate pushdown: greater than or equal
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 >= 2;
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 >= 2;
 ----
 David	2
 Eve	2
@@ -182,7 +182,7 @@ Iris	3
 
 # predicate pushdown: range filter with less than and greater than combined
 query III
-SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 >= 2 AND f2 < 2;
+SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 >= 2 AND f2 < 2;
 ----
 David	2	0
 Eve	2	1
@@ -191,7 +191,7 @@ Henry	3	1
 
 # predicate pushdown: not equal combined with OR
 query III
-SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 != 2 OR f2 = 0;
+SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 != 2 OR f2 = 0;
 ----
 Alice	1	0
 Bob	1	1
@@ -203,7 +203,7 @@ Iris	3	2
 
 # predicate pushdown: constant on left side (flipped comparison)
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE 2 < f1;
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE 2 < f1;
 ----
 Grace	3
 Henry	3
@@ -211,12 +211,12 @@ Iris	3
 
 # predicate pushdown: IS NULL (no nulls in test data, expect empty result)
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f0 IS NULL;
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f0 IS NULL;
 ----
 
 # predicate pushdown: IS NOT NULL (no nulls in test data, expect all rows)
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f0 IS NOT NULL;
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f0 IS NOT NULL;
 ----
 Alice	1
 Bob	1
@@ -230,12 +230,12 @@ Iris	3
 
 # predicate pushdown: IS NULL on integer column
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 IS NULL;
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 IS NULL;
 ----
 
 # predicate pushdown: IS NOT NULL combined with AND
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f0 IS NOT NULL AND f1 = 1;
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f0 IS NOT NULL AND f1 = 1;
 ----
 Alice	1
 Bob	1
@@ -243,7 +243,7 @@ Cathy	1
 
 # predicate pushdown: IS NOT NULL combined with OR
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f0 IS NOT NULL OR f1 = 1;
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f0 IS NOT NULL OR f1 = 1;
 ----
 Alice	1
 Bob	1
@@ -257,7 +257,7 @@ Iris	3
 
 # predicate pushdown: BETWEEN (inclusive on both ends)
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 BETWEEN 1 AND 2;
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 BETWEEN 1 AND 2;
 ----
 Alice	1
 Bob	1
@@ -268,7 +268,7 @@ Frank	2
 
 # predicate pushdown: NOT BETWEEN
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 NOT BETWEEN 1 AND 2;
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 NOT BETWEEN 1 AND 2;
 ----
 Grace	3
 Henry	3
@@ -276,7 +276,7 @@ Iris	3
 
 # predicate pushdown: BETWEEN on second column
 query III
-SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f2 BETWEEN 1 AND 2;
+SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f2 BETWEEN 1 AND 2;
 ----
 Bob	1	1
 Cathy	1	2
@@ -288,7 +288,7 @@ Iris	3	2
 # predicate pushdown: exclusive range (x > a AND x < b) — optimizer may merge
 # into a non-inclusive BoundBetweenExpression; must still push down correctly.
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 > 1 AND f1 < 3;
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 > 1 AND f1 < 3;
 ----
 David	2
 Eve	2
@@ -296,7 +296,7 @@ Frank	2
 
 # predicate pushdown: half-open range (x >= a AND x < b)
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 >= 1 AND f1 < 3;
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 >= 1 AND f1 < 3;
 ----
 Alice	1
 Bob	1
@@ -307,7 +307,7 @@ Frank	2
 
 # predicate pushdown: half-open range (x > a AND x <= b)
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f1 > 1 AND f1 <= 3;
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 > 1 AND f1 <= 3;
 ----
 David	2
 Eve	2
@@ -318,13 +318,13 @@ Iris	3
 
 # predicate pushdown: LIKE prefix (optimizer rewrites to prefix())
 query I
-SELECT f0 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f0 LIKE 'A%';
+SELECT f0 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f0 LIKE 'A%';
 ----
 Alice
 
 # predicate pushdown: LIKE suffix (optimizer rewrites to suffix())
 query I
-SELECT f0 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f0 LIKE '%e';
+SELECT f0 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f0 LIKE '%e';
 ----
 Alice
 Eve
@@ -332,7 +332,7 @@ Grace
 
 # predicate pushdown: LIKE contains (optimizer rewrites to contains())
 query I
-SELECT f0 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f0 LIKE '%a%';
+SELECT f0 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f0 LIKE '%a%';
 ----
 Cathy
 David
@@ -341,13 +341,13 @@ Grace
 
 # predicate pushdown: LIKE complex pattern (not optimized, stays as ~~)
 query I
-SELECT f0 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f0 LIKE '_l%';
+SELECT f0 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f0 LIKE '_l%';
 ----
 Alice
 
 # predicate pushdown: NOT LIKE prefix (optimizer rewrites to NOT(prefix()))
 query I
-SELECT f0 FROM paimon_scan('./data/testdb.db/testtbl', manifest_format='orc') WHERE f0 NOT LIKE 'A%';
+SELECT f0 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f0 NOT LIKE 'A%';
 ----
 Bob
 Cathy

--- a/test/sql/timestamp.test
+++ b/test/sql/timestamp.test
@@ -23,18 +23,18 @@ require paimon
 
 # equality
 query II
-SELECT col_string, col_timestamp FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_timestamp = TIMESTAMP '2025-01-15 10:30:00';
+SELECT col_string, col_timestamp FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_timestamp = TIMESTAMP '2025-01-15 10:30:00';
 ----
 Alice	2025-01-15 10:30:00
 
 # equality with no match
 query II
-SELECT col_string, col_timestamp FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_timestamp = TIMESTAMP '2099-01-01 00:00:00';
+SELECT col_string, col_timestamp FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_timestamp = TIMESTAMP '2099-01-01 00:00:00';
 ----
 
 # not equal
 query I
-SELECT col_string FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_timestamp != TIMESTAMP '2025-01-15 10:30:00' ORDER BY col_string;
+SELECT col_string FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_timestamp != TIMESTAMP '2025-01-15 10:30:00' ORDER BY col_string;
 ----
 Bob
 Cathy
@@ -47,7 +47,7 @@ Iris
 
 # greater than
 query II
-SELECT col_string, col_timestamp FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_timestamp > TIMESTAMP '2025-12-31 23:59:59';
+SELECT col_string, col_timestamp FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_timestamp > TIMESTAMP '2025-12-31 23:59:59';
 ----
 Grace	2026-01-01 00:00:00
 Henry	2026-02-14 09:30:00
@@ -55,14 +55,14 @@ Iris	2026-04-20 18:00:00
 
 # less than
 query II
-SELECT col_string, col_timestamp FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_timestamp < TIMESTAMP '2025-03-21 00:00:00';
+SELECT col_string, col_timestamp FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_timestamp < TIMESTAMP '2025-03-21 00:00:00';
 ----
 Alice	2025-01-15 10:30:00
 Bob	2025-03-20 14:15:30
 
 # greater than or equal
 query II
-SELECT col_string, col_timestamp FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_timestamp >= TIMESTAMP '2025-11-25 20:30:00';
+SELECT col_string, col_timestamp FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_timestamp >= TIMESTAMP '2025-11-25 20:30:00';
 ----
 Frank	2025-11-25 20:30:00
 Grace	2026-01-01 00:00:00
@@ -71,14 +71,14 @@ Iris	2026-04-20 18:00:00
 
 # less than or equal
 query II
-SELECT col_string, col_timestamp FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_timestamp <= TIMESTAMP '2025-03-20 14:15:30';
+SELECT col_string, col_timestamp FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_timestamp <= TIMESTAMP '2025-03-20 14:15:30';
 ----
 Alice	2025-01-15 10:30:00
 Bob	2025-03-20 14:15:30
 
 # range with AND
 query II
-SELECT col_string, col_timestamp FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_timestamp >= TIMESTAMP '2025-06-01 00:00:00' AND col_timestamp <= TIMESTAMP '2025-11-25 20:30:00';
+SELECT col_string, col_timestamp FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_timestamp >= TIMESTAMP '2025-06-01 00:00:00' AND col_timestamp <= TIMESTAMP '2025-11-25 20:30:00';
 ----
 Cathy	2025-06-01 08:00:00
 David	2025-07-04 12:00:00
@@ -87,7 +87,7 @@ Frank	2025-11-25 20:30:00
 
 # BETWEEN
 query II
-SELECT col_string, col_timestamp FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_timestamp BETWEEN TIMESTAMP '2025-07-01 00:00:00' AND TIMESTAMP '2026-01-01 00:00:00';
+SELECT col_string, col_timestamp FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_timestamp BETWEEN TIMESTAMP '2025-07-01 00:00:00' AND TIMESTAMP '2026-01-01 00:00:00';
 ----
 David	2025-07-04 12:00:00
 Eve	2025-09-10 16:45:00
@@ -96,7 +96,7 @@ Grace	2026-01-01 00:00:00
 
 # IN list
 query II
-SELECT col_string, col_timestamp FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_timestamp IN (TIMESTAMP '2025-01-15 10:30:00', TIMESTAMP '2025-09-10 16:45:00', TIMESTAMP '2026-04-20 18:00:00');
+SELECT col_string, col_timestamp FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_timestamp IN (TIMESTAMP '2025-01-15 10:30:00', TIMESTAMP '2025-09-10 16:45:00', TIMESTAMP '2026-04-20 18:00:00');
 ----
 Alice	2025-01-15 10:30:00
 Eve	2025-09-10 16:45:00
@@ -104,13 +104,13 @@ Iris	2026-04-20 18:00:00
 
 # IS NULL (row 10 has NULL timestamp)
 query I
-SELECT col_string FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_timestamp IS NULL;
+SELECT col_string FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_timestamp IS NULL;
 ----
 NULL
 
 # IS NOT NULL (rows 1-9 have non-NULL timestamps)
 query I
-SELECT col_string FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_timestamp IS NOT NULL ORDER BY col_string;
+SELECT col_string FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_timestamp IS NOT NULL ORDER BY col_string;
 ----
 Alice
 Bob
@@ -124,7 +124,7 @@ Iris
 
 # constant on left side (flipped comparison)
 query II
-SELECT col_string, col_timestamp FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE TIMESTAMP '2025-12-31 23:59:59' < col_timestamp;
+SELECT col_string, col_timestamp FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE TIMESTAMP '2025-12-31 23:59:59' < col_timestamp;
 ----
 Grace	2026-01-01 00:00:00
 Henry	2026-02-14 09:30:00
@@ -132,7 +132,7 @@ Iris	2026-04-20 18:00:00
 
 # combined: timestamp AND integer
 query III
-SELECT col_string, col_timestamp, col_int FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_timestamp > TIMESTAMP '2025-06-01 00:00:00' AND col_int > 0 ORDER BY col_string;
+SELECT col_string, col_timestamp, col_int FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_timestamp > TIMESTAMP '2025-06-01 00:00:00' AND col_int > 0 ORDER BY col_string;
 ----
 Cathy	2025-06-01 08:00:00	3000
 Eve	2025-09-10 16:45:00	100000
@@ -141,7 +141,7 @@ Iris	2026-04-20 18:00:00	9999
 
 # combined: timestamp OR string
 query II
-SELECT col_string, col_timestamp FROM paimon_scan('./data/testdb.db/type_test_tbl', manifest_format='orc') WHERE col_timestamp = TIMESTAMP '2025-01-15 10:30:00' OR col_string = 'Iris';
+SELECT col_string, col_timestamp FROM paimon_scan('./data/testdb.db/type_test_tbl') WHERE col_timestamp = TIMESTAMP '2025-01-15 10:30:00' OR col_string = 'Iris';
 ----
 Alice	2025-01-15 10:30:00
 Iris	2026-04-20 18:00:00


### PR DESCRIPTION
## Summary

- Stop injecting hardcoded manifest/data file format defaults into the
  paimon options map; only forward format options when the user
  explicitly provides them
- Let paimon-cpp resolve the correct formats from the table schema,
  which already stores `manifest.format` and `file.format` on disk
- Mark the `manifest_format` and `file_format` named parameters as
  deprecated in scan functions; remove explicit format arguments from
  all tests

## Test plan

- [ ] `make test` passes on existing test suite
- [ ] Tables with ORC manifests are read correctly without explicit
  `manifest_format` parameter
- [ ] Tables with Avro manifests continue to work
- [ ] Explicitly passing a format still overrides the schema value

🤖 Generated with [Claude Code](https://claude.com/claude-code)