### PR TITLE
feat(scan): add snapshot-based time travel queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This extension is built on top of [paimon-cpp](https://github.com/alibaba/paimon
 - Catalog ATTACH support
 - DuckDB Secret-based OSS credential management
 - Snapshot history inspection
+- Snapshot-based time travel queries
 
 ## Use Cases
 
@@ -170,6 +171,30 @@ ORDER BY snapshot_id;
 -- SELECT snapshot_id, commit_kind, commit_time, total_record_count
 -- FROM paimon_snapshots('oss://your-bucket/warehouse', 'your_db', 'your_table')
 -- ORDER BY snapshot_id;
+```
+
+### Time Travel Queries
+
+Query a historical version of a table by snapshot ID or by timestamp. Use `paimon_snapshots` first to identify the snapshot you want.
+
+```sql
+-- Read from a specific snapshot (6 rows — state after the second append)
+SELECT * FROM paimon_scan('./data/testdb.db/testtbl', snapshot_from_id=2);
+
+-- Read from a point in time (returns the snapshot active at that moment)
+SELECT * FROM paimon_scan('./data/testdb.db/testtbl', snapshot_from_timestamp=TIMESTAMP '2026-01-15 10:48:23.5');
+```
+
+When using an ATTACHed catalog, the same functionality is available via DuckDB's native `AT` clause:
+
+```sql
+ATTACH './data' AS my_catalog (TYPE paimon);
+
+-- AT (VERSION => snapshot_id)
+SELECT count(*) FROM my_catalog.testdb.testtbl AT (VERSION => 2);
+
+-- AT (TIMESTAMP => point_in_time)
+SELECT count(*) FROM my_catalog.testdb.testtbl AT (TIMESTAMP => TIMESTAMP '2026-01-15 10:48:23.5');
 ```
 
 ## Related Projects

--- a/src/include/paimon_catalog.hpp
+++ b/src/include/paimon_catalog.hpp
@@ -70,8 +70,15 @@ public:
 	                             PhysicalOperator &plan) override;
 
 	DatabaseSize GetDatabaseSize(ClientContext &context) override;
-	bool InMemory() override;
-	string GetDBPath() override;
+	bool SupportsTimeTravel() const override {
+		return true;
+	}
+	bool InMemory() override {
+		return false;
+	}
+	string GetDBPath() override {
+		return path;
+	}
 
 	PaimonSchemaSet &GetSchemas() {
 		return schemas;

--- a/src/include/paimon_table_entry.hpp
+++ b/src/include/paimon_table_entry.hpp
@@ -25,6 +25,8 @@
 #pragma once
 
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/catalog/entry_lookup_info.hpp"
+#include "duckdb/planner/tableref/bound_at_clause.hpp"
 #include "duckdb/storage/table_storage_info.hpp"
 
 namespace duckdb {
@@ -35,6 +37,8 @@ public:
 
 	unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, column_t column_id) override;
 	TableFunction GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data) override;
+	TableFunction GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data,
+	                              const EntryLookupInfo &lookup_info) override;
 	TableStorageInfo GetStorageInfo(ClientContext &context) override;
 	virtual_column_map_t GetVirtualColumns() const override;
 	vector<column_t> GetRowIdColumns() const override;

--- a/src/paimon_storage/paimon_catalog.cpp
+++ b/src/paimon_storage/paimon_catalog.cpp
@@ -24,6 +24,7 @@
 
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/parser/parsed_data/create_schema_info.hpp"
 #include "duckdb/parser/parsed_data/drop_info.hpp"
@@ -40,9 +41,9 @@
 
 namespace duckdb {
 
-static std::optional<string> TryGetPaimonOptionValue(const unordered_map<string, Value> &attached_options,
+static std::optional<string> TryGetPaimonOptionValue(const unordered_map<string, Value> &input_options,
                                                      const string &key) {
-	for (const auto &entry : attached_options) {
+	for (const auto &entry : input_options) {
 		if (StringUtil::CIEquals(entry.first, key)) {
 			return entry.second.ToString();
 		}
@@ -50,9 +51,9 @@ static std::optional<string> TryGetPaimonOptionValue(const unordered_map<string,
 	return {};
 }
 
-static string GetValidatedFormatOption(const unordered_map<string, Value> &attached_options, const string &key,
+static string GetValidatedFormatOption(const unordered_map<string, Value> &input_options, const string &key,
                                        const string &default_value, const vector<string> &supported_values) {
-	auto raw_value = TryGetPaimonOptionValue(attached_options, key);
+	auto raw_value = TryGetPaimonOptionValue(input_options, key);
 	if (!raw_value.has_value()) {
 		return default_value;
 	}
@@ -127,6 +128,20 @@ map<string, string> PaimonCatalog::GetPaimonOptions(ClientContext &context, cons
 	}
 
 	paimon_options.insert({paimon::Options::READ_BATCH_SIZE, std::to_string(STANDARD_VECTOR_SIZE)});
+
+	auto snap_id = TryGetPaimonOptionValue(input_options, "snapshot_from_id");
+	auto snap_ts = TryGetPaimonOptionValue(input_options, "snapshot_from_timestamp");
+	if (snap_id.has_value() && snap_ts.has_value()) {
+		throw InvalidInputException("Cannot specify both 'snapshot_from_id' and 'snapshot_from_timestamp'");
+	}
+	if (snap_id.has_value()) {
+		paimon_options[paimon::Options::SCAN_SNAPSHOT_ID] = snap_id.value();
+	}
+	if (snap_ts.has_value()) {
+		auto ts = Timestamp::FromString(snap_ts.value(), false);
+		auto epoch_ms = Timestamp::GetEpochMs(ts);
+		paimon_options[paimon::Options::SCAN_TIMESTAMP_MILLIS] = std::to_string(epoch_ms);
+	}
 
 	return paimon_options;
 }
@@ -215,14 +230,6 @@ PhysicalOperator &PaimonCatalog::PlanUpdate(ClientContext &, PhysicalPlanGenerat
 
 DatabaseSize PaimonCatalog::GetDatabaseSize(ClientContext &) {
 	throw NotImplementedException("GetDatabaseSize not supported yet");
-}
-
-bool PaimonCatalog::InMemory() {
-	return false;
-}
-
-string PaimonCatalog::GetDBPath() {
-	return path;
 }
 
 void PaimonCatalog::DropSchema(ClientContext &, DropInfo &) {

--- a/src/paimon_storage/paimon_scan.cpp
+++ b/src/paimon_storage/paimon_scan.cpp
@@ -698,6 +698,8 @@ TableFunctionSet PaimonFunctions::GetPaimonScanFunction() {
 	                         PaimonScanBind, PaimonScanInitGlobal);
 	fun.named_parameters["manifest_format"] = LogicalType::VARCHAR; // deprecated: auto-detected from table schema
 	fun.named_parameters["file_format"] = LogicalType::VARCHAR;     // deprecated: auto-detected from table schema
+	fun.named_parameters["snapshot_from_id"] = LogicalType::BIGINT;
+	fun.named_parameters["snapshot_from_timestamp"] = LogicalType::TIMESTAMP;
 	fun.init_local = PaimonScanInitLocal;
 	fun.projection_pushdown = true;
 	fun.pushdown_complex_filter = PaimonPushdownFilter;
@@ -706,6 +708,8 @@ TableFunctionSet PaimonFunctions::GetPaimonScanFunction() {
 	auto fun_fullpath = TableFunction({LogicalType::VARCHAR}, PaimonScan, PaimonScanBind, PaimonScanInitGlobal);
 	fun_fullpath.named_parameters["manifest_format"] = LogicalType::VARCHAR; // deprecated
 	fun_fullpath.named_parameters["file_format"] = LogicalType::VARCHAR;     // deprecated
+	fun_fullpath.named_parameters["snapshot_from_id"] = LogicalType::BIGINT;
+	fun_fullpath.named_parameters["snapshot_from_timestamp"] = LogicalType::TIMESTAMP;
 	fun_fullpath.init_local = PaimonScanInitLocal;
 	fun_fullpath.projection_pushdown = true;
 	fun_fullpath.pushdown_complex_filter = PaimonPushdownFilter;

--- a/src/paimon_storage/paimon_table_entry.cpp
+++ b/src/paimon_storage/paimon_table_entry.cpp
@@ -25,9 +25,11 @@
 #include "paimon_table_entry.hpp"
 
 #include "duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/parser/tableref/table_function_ref.hpp"
+#include "duckdb/planner/tableref/bound_at_clause.hpp"
 
 #include "paimon_catalog.hpp"
 
@@ -42,6 +44,12 @@ unique_ptr<BaseStatistics> PaimonTableEntry::GetStatistics(ClientContext &contex
 }
 
 TableFunction PaimonTableEntry::GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data) {
+	EntryLookupInfo lookup(CatalogType::TABLE_ENTRY, name);
+	return GetScanFunction(context, bind_data, lookup);
+}
+
+TableFunction PaimonTableEntry::GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data,
+                                                const EntryLookupInfo &lookup_info) {
 	auto &db = DatabaseInstance::GetDatabase(context);
 	auto &system_catalog = Catalog::GetSystemCatalog(db);
 	auto transaction = CatalogTransaction::GetSystemTransaction(db);
@@ -62,6 +70,20 @@ TableFunction PaimonTableEntry::GetScanFunction(ClientContext &context, unique_p
 	for (const auto &entry : paimon_catalog.GetAttachOptions()) {
 		param_map[entry.first] = entry.second;
 	}
+
+	auto at_clause = lookup_info.GetAtClause();
+	if (at_clause) {
+		auto unit = StringUtil::Upper(at_clause->Unit());
+		if (unit == "VERSION") {
+			param_map["snapshot_from_id"] = at_clause->GetValue().CastAs(context, LogicalType::BIGINT);
+		} else if (unit == "TIMESTAMP") {
+			param_map["snapshot_from_timestamp"] = at_clause->GetValue().CastAs(context, LogicalType::TIMESTAMP);
+		} else {
+			throw InvalidInputException("Unsupported AT unit \"%s\" for Paimon. Use VERSION or TIMESTAMP.",
+			                            at_clause->Unit());
+		}
+	}
+
 	vector<LogicalType> return_types;
 	vector<string> names;
 	TableFunctionRef empty_ref;

--- a/test/sql/paimon_time_travel.test
+++ b/test/sql/paimon_time_travel.test
@@ -1,0 +1,91 @@
+# name: test/sql/paimon_time_travel.test
+# group: [sql]
+
+require paimon
+
+# snapshot 1: first batch only (3 rows)
+query I
+SELECT count(*) FROM paimon_scan('./data/testdb.db/testtbl', snapshot_from_id=1);
+----
+3
+
+# snapshot 2: first two batches (6 rows)
+query I
+SELECT count(*) FROM paimon_scan('./data/testdb.db/testtbl', snapshot_from_id=2);
+----
+6
+
+# snapshot 3: all batches (9 rows), same as latest
+query I
+SELECT count(*) FROM paimon_scan('./data/testdb.db/testtbl', snapshot_from_id=3);
+----
+9
+
+# verify data content at snapshot 1
+query IIII
+SELECT * FROM paimon_scan('./data/testdb.db/testtbl', snapshot_from_id=1);
+----
+Alice	1	0	11.0
+Bob	1	1	12.1
+Cathy	1	2	13.2
+
+# 3-arg form with snapshot_from_id
+query I
+SELECT count(*) FROM paimon_scan('./data', 'testdb', 'testtbl', snapshot_from_id=1);
+----
+3
+
+# snapshot_from_timestamp with far-future timestamp returns latest snapshot
+query I
+SELECT count(*) FROM paimon_scan('./data/testdb.db/testtbl', snapshot_from_timestamp=TIMESTAMP '2099-01-01');
+----
+9
+
+# error: cannot use both snapshot_from_id and snapshot_from_timestamp
+statement error
+SELECT * FROM paimon_scan('./data/testdb.db/testtbl', snapshot_from_id=1, snapshot_from_timestamp=TIMESTAMP '2099-01-01');
+----
+Cannot specify both 'snapshot_from_id' and 'snapshot_from_timestamp'
+
+# AT (VERSION => N) via ATTACHed catalog
+statement ok
+ATTACH './data' AS cat (TYPE paimon);
+
+query I
+SELECT count(*) FROM cat.testdb.testtbl AT (VERSION => 1);
+----
+3
+
+query I
+SELECT count(*) FROM cat.testdb.testtbl AT (VERSION => 2);
+----
+6
+
+query I
+SELECT count(*) FROM cat.testdb.testtbl AT (VERSION => 3);
+----
+9
+
+# AT (TIMESTAMP => before snapshot 2) returns snapshot 1
+query I
+SELECT count(*) FROM cat.testdb.testtbl AT (TIMESTAMP => TIMESTAMP '2026-01-15 10:48:23.5');
+----
+3
+
+# AT (TIMESTAMP => between snapshot 2 and 3) returns snapshot 2
+query I
+SELECT count(*) FROM cat.testdb.testtbl AT (TIMESTAMP => TIMESTAMP '2026-01-15 10:48:23.52');
+----
+6
+
+# AT (TIMESTAMP => exactly snapshot 3) returns snapshot 3
+query I
+SELECT count(*) FROM cat.testdb.testtbl AT (TIMESTAMP => TIMESTAMP '2026-01-15 10:48:23.528');
+----
+9
+
+# error: invalid AT unit rejected by parser
+statement error
+SELECT * FROM cat.testdb.testtbl AT (SYSTEM_TIME => TIMESTAMP '2099-01-01');
+----
+syntax error


### PR DESCRIPTION
Expose paimon-cpp's scan.snapshot-id and scan.timestamp-millis options as named parameters on the paimon_scan table function, enabling users to query historical versions of Paimon tables. The two parameters are mutually exclusive: one accepts a snapshot ID directly, the other accepts a DuckDB timestamp and converts it to epoch milliseconds for paimon-cpp.

Snapshot parameter extraction is consolidated in the unified named-parameter-to-paimon-option translator rather than at the scan bind site, keeping the translation path consistent and making the parameters available to both the table function and the catalog scan path.

ATTACH catalog queries gain the same capability through DuckDB's native AT (VERSION => ...) and AT (TIMESTAMP => ...) syntax. The catalog opts in to time travel, and the table entry's scan function extracts the AT clause and injects it as the equivalent named parameters, so the unified translator handles both access patterns without duplication.