### PR TITLE
feat(catalog): support CREATE/DROP TABLE and SCHEMA (v1.5)

### DIFF
--- a/src/include/paimon_catalog.hpp
+++ b/src/include/paimon_catalog.hpp
@@ -69,6 +69,7 @@ public:
 	PhysicalOperator &PlanUpdate(ClientContext &context, PhysicalPlanGenerator &planner, LogicalUpdate &op,
 	                             PhysicalOperator &plan) override;
 
+	ErrorData SupportsCreateTable(BoundCreateTableInfo &info) override;
 	DatabaseSize GetDatabaseSize(ClientContext &context) override;
 	bool SupportsTimeTravel() const override {
 		return true;

--- a/src/include/paimon_schema_set.hpp
+++ b/src/include/paimon_schema_set.hpp
@@ -36,6 +36,8 @@ public:
 public:
 	optional_ptr<CatalogEntry> GetEntry(ClientContext &context, const string &name);
 	void Scan(ClientContext &context, const std::function<void(CatalogEntry &)> &callback);
+	optional_ptr<CatalogEntry> CreateEntry(const string &name);
+	void DropEntry(const string &name);
 
 private:
 	Catalog &catalog;

--- a/src/include/paimon_table_set.hpp
+++ b/src/include/paimon_table_set.hpp
@@ -27,6 +27,8 @@
 namespace duckdb {
 
 class PaimonSchemaEntry;
+class PaimonCatalog;
+struct CreateTableInfo;
 
 class PaimonTableSet {
 public:
@@ -34,6 +36,9 @@ public:
 
 	optional_ptr<CatalogEntry> GetEntry(ClientContext &context, const EntryLookupInfo &lookup);
 	void Scan(ClientContext &context, const std::function<void(CatalogEntry &)> &callback);
+	optional_ptr<CatalogEntry> CreateEntry(CreateTableInfo &info);
+	optional_ptr<CatalogEntry> RefreshEntry(ClientContext &context, const string &table_name);
+	void DropEntry(const string &table_name);
 
 private:
 	PaimonSchemaEntry &schema;

--- a/src/paimon_storage/paimon_catalog.cpp
+++ b/src/paimon_storage/paimon_catalog.cpp
@@ -167,7 +167,9 @@ PaimonCatalog::PaimonCatalog(ClientContext &context, AttachedDatabase &db, const
 unique_ptr<Catalog> PaimonCatalog::Attach(optional_ptr<StorageExtensionInfo> storage_info, ClientContext &context,
                                           AttachedDatabase &db, const string &name, AttachInfo &info,
                                           AttachOptions &options) {
-	db.SetReadOnlyDatabase();
+	if (options.access_mode == AccessMode::READ_ONLY) {
+		db.SetReadOnlyDatabase();
+	}
 	return make_uniq<PaimonCatalog>(context, db, info.path, info.options, options.access_mode);
 }
 
@@ -183,8 +185,16 @@ string PaimonCatalog::GetCatalogType() {
 	return "paimon";
 }
 
-optional_ptr<CatalogEntry> PaimonCatalog::CreateSchema(CatalogTransaction, CreateSchemaInfo &) {
-	throw NotImplementedException("CreateSchema not supported yet");
+optional_ptr<CatalogEntry> PaimonCatalog::CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) {
+	bool ignore_if_exists = info.on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT;
+	auto status = paimon_catalog->CreateDatabase(info.schema, {}, ignore_if_exists);
+	if (!status.ok()) {
+		if (status.IsExist() || status.IsNotExist()) {
+			throw CatalogException(status.ToString());
+		}
+		throw IOException(status.ToString());
+	}
+	return schemas.CreateEntry(info.schema);
 }
 
 optional_ptr<SchemaCatalogEntry> PaimonCatalog::LookupSchema(CatalogTransaction transaction,
@@ -232,8 +242,16 @@ DatabaseSize PaimonCatalog::GetDatabaseSize(ClientContext &) {
 	throw NotImplementedException("GetDatabaseSize not supported yet");
 }
 
-void PaimonCatalog::DropSchema(ClientContext &, DropInfo &) {
-	throw NotImplementedException("DropSchema not supported yet");
+void PaimonCatalog::DropSchema(ClientContext &context, DropInfo &info) {
+	bool ignore_if_not_exists = info.if_not_found == OnEntryNotFound::RETURN_NULL;
+	auto status = paimon_catalog->DropDatabase(info.name, ignore_if_not_exists, info.cascade);
+	if (!status.ok()) {
+		if (status.IsExist() || status.IsNotExist()) {
+			throw CatalogException(status.ToString());
+		}
+		throw IOException(status.ToString());
+	}
+	schemas.DropEntry(info.name);
 }
 
 } // namespace duckdb

--- a/src/paimon_storage/paimon_catalog.cpp
+++ b/src/paimon_storage/paimon_catalog.cpp
@@ -29,6 +29,8 @@
 #include "duckdb/parser/parsed_data/create_schema_info.hpp"
 #include "duckdb/parser/parsed_data/drop_info.hpp"
 #include "duckdb/parser/parsed_data/attach_info.hpp"
+#include "duckdb/parser/parsed_data/create_table_info.hpp"
+#include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
 
 #include "paimon_catalog.hpp"
 #include "paimon_schema_entry.hpp"
@@ -240,6 +242,15 @@ PhysicalOperator &PaimonCatalog::PlanUpdate(ClientContext &, PhysicalPlanGenerat
 
 DatabaseSize PaimonCatalog::GetDatabaseSize(ClientContext &) {
 	throw NotImplementedException("GetDatabaseSize not supported yet");
+}
+
+ErrorData PaimonCatalog::SupportsCreateTable(BoundCreateTableInfo &info) {
+	auto &base = info.Base();
+	if (!base.sort_keys.empty()) {
+		return ErrorData(ExceptionType::CATALOG,
+		                 StringUtil::Format("SORTED BY is not supported for tables in a %s catalog", GetCatalogType()));
+	}
+	return ErrorData();
 }
 
 void PaimonCatalog::DropSchema(ClientContext &context, DropInfo &info) {

--- a/src/paimon_storage/paimon_schema_entry.cpp
+++ b/src/paimon_storage/paimon_schema_entry.cpp
@@ -23,8 +23,14 @@
  */
 
 #include "duckdb/catalog/catalog.hpp"
+#include "duckdb/common/arrow/arrow_converter.hpp"
 #include "duckdb/function/table/arrow.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
+#include "duckdb/parser/parsed_data/drop_info.hpp"
+#include "duckdb/parser/constraints/unique_constraint.hpp"
+#include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
+
+#include "paimon/catalog/identifier.h"
 
 #include "paimon_catalog.hpp"
 #include "paimon_schema_entry.hpp"
@@ -77,8 +83,61 @@ optional_ptr<CatalogEntry> PaimonSchemaEntry::CreateFunction(CatalogTransaction,
 	throw NotImplementedException("CreateFunction not supported yet");
 }
 
-optional_ptr<CatalogEntry> PaimonSchemaEntry::CreateTable(CatalogTransaction, BoundCreateTableInfo &) {
-	throw NotImplementedException("CreateTable not supported yet");
+optional_ptr<CatalogEntry> PaimonSchemaEntry::CreateTable(CatalogTransaction transaction, BoundCreateTableInfo &info) {
+	auto &base = info.Base();
+	if (base.on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
+		throw NotImplementedException("CREATE OR REPLACE TABLE is not supported for Paimon tables");
+	}
+
+	auto &catalog = ParentCatalog().Cast<PaimonCatalog>();
+	auto &paimon_catalog = catalog.GetPaimonCatalog();
+	paimon::Identifier identifier(name, base.table);
+
+	auto col_names = base.columns.GetColumnNames();
+	auto col_types = base.columns.GetColumnTypes();
+
+	ArrowSchema arrow_schema {};
+	auto client_props = transaction.GetContext().GetClientProperties();
+	ArrowConverter::ToArrowSchema(&arrow_schema, col_types, col_names, client_props);
+	struct ArrowSchemaGuard {
+		ArrowSchema &schema;
+		~ArrowSchemaGuard() {
+			if (schema.release) {
+				schema.release(&schema);
+			}
+		}
+	} arrow_guard {arrow_schema};
+
+	vector<string> primary_keys;
+	for (auto &constraint : info.constraints) {
+		if (constraint->type != ConstraintType::UNIQUE) {
+			continue;
+		}
+		auto &unique = constraint->Cast<UniqueConstraint>();
+		if (!unique.IsPrimaryKey()) {
+			continue;
+		}
+		if (unique.HasIndex()) {
+			auto col_idx = unique.GetIndex();
+			primary_keys.push_back(col_names[col_idx.index]);
+		} else {
+			for (auto &col_name : unique.GetColumnNames()) {
+				primary_keys.push_back(col_name);
+			}
+		}
+	}
+
+	bool ignore_if_exists = base.on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT;
+	auto status = paimon_catalog.CreateTable(identifier, &arrow_schema, {}, primary_keys, {}, ignore_if_exists);
+
+	if (!status.ok()) {
+		if (status.IsExist() || status.IsNotExist()) {
+			throw CatalogException(status.ToString());
+		}
+		throw IOException(status.ToString());
+	}
+
+	return tables.RefreshEntry(transaction.GetContext(), base.table);
 }
 
 optional_ptr<CatalogEntry> PaimonSchemaEntry::CreateView(CatalogTransaction, CreateViewInfo &) {
@@ -109,8 +168,25 @@ optional_ptr<CatalogEntry> PaimonSchemaEntry::CreateType(CatalogTransaction, Cre
 	throw NotImplementedException("CreateType not supported yet");
 }
 
-void PaimonSchemaEntry::DropEntry(ClientContext &, DropInfo &) {
-	throw NotImplementedException("DropEntry not supported yet");
+void PaimonSchemaEntry::DropEntry(ClientContext &context, DropInfo &info) {
+	if (info.type != CatalogType::TABLE_ENTRY) {
+		throw NotImplementedException("Only dropping tables is supported");
+	}
+
+	auto &catalog = ParentCatalog().Cast<PaimonCatalog>();
+	auto &paimon_catalog = catalog.GetPaimonCatalog();
+	paimon::Identifier identifier(name, info.name);
+
+	bool ignore_if_not_exists = info.if_not_found == OnEntryNotFound::RETURN_NULL;
+	auto status = paimon_catalog.DropTable(identifier, ignore_if_not_exists);
+	if (!status.ok()) {
+		if (status.IsExist() || status.IsNotExist()) {
+			throw CatalogException(status.ToString());
+		}
+		throw IOException(status.ToString());
+	}
+
+	tables.DropEntry(info.name);
 }
 
 void PaimonSchemaEntry::Alter(CatalogTransaction, AlterInfo &) {

--- a/src/paimon_storage/paimon_schema_entry.cpp
+++ b/src/paimon_storage/paimon_schema_entry.cpp
@@ -25,6 +25,8 @@
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/common/arrow/arrow_converter.hpp"
 #include "duckdb/function/table/arrow.hpp"
+#include "duckdb/parser/expression/columnref_expression.hpp"
+#include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
 #include "duckdb/parser/parsed_data/drop_info.hpp"
 #include "duckdb/parser/constraints/unique_constraint.hpp"
@@ -127,8 +129,33 @@ optional_ptr<CatalogEntry> PaimonSchemaEntry::CreateTable(CatalogTransaction tra
 		}
 	}
 
+	vector<string> partition_keys;
+	for (auto &pk_expr : base.partition_keys) {
+		if (pk_expr->GetExpressionType() == ExpressionType::COLUMN_REF) {
+			partition_keys.push_back(pk_expr->Cast<ColumnRefExpression>().GetColumnName());
+		} else {
+			throw InvalidInputException("Paimon partition key must be a column reference");
+		}
+	}
+
+	std::map<string, string> paimon_options;
+	for (auto &opt : base.options) {
+		auto &expr = *opt.second;
+		if (expr.GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
+			auto &val = expr.Cast<ConstantExpression>().value;
+			if (!val.IsNull()) {
+				paimon_options[opt.first] = val.ToString();
+			}
+		} else if (expr.GetExpressionType() == ExpressionType::COLUMN_REF) {
+			paimon_options[opt.first] = expr.Cast<ColumnRefExpression>().GetColumnName();
+		} else {
+			throw InvalidInputException("Paimon table option '%s' must be a literal value", opt.first);
+		}
+	}
+
 	bool ignore_if_exists = base.on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT;
-	auto status = paimon_catalog.CreateTable(identifier, &arrow_schema, {}, primary_keys, {}, ignore_if_exists);
+	auto status = paimon_catalog.CreateTable(identifier, &arrow_schema, partition_keys, primary_keys, paimon_options,
+	                                         ignore_if_exists);
 
 	if (!status.ok()) {
 		if (status.IsExist() || status.IsNotExist()) {

--- a/src/paimon_storage/paimon_schema_set.cpp
+++ b/src/paimon_storage/paimon_schema_set.cpp
@@ -78,4 +78,18 @@ optional_ptr<CatalogEntry> PaimonSchemaSet::GetEntry(ClientContext &context, con
 	return entry->second.get();
 }
 
+optional_ptr<CatalogEntry> PaimonSchemaSet::CreateEntry(const string &name) {
+	lock_guard<mutex> l(entry_lock);
+	CreateSchemaInfo info;
+	info.schema = name;
+	auto schema_entry = make_uniq<PaimonSchemaEntry>(catalog, info);
+	auto result = entries.emplace(make_pair(name, std::move(schema_entry)));
+	return result.first->second.get();
+}
+
+void PaimonSchemaSet::DropEntry(const string &name) {
+	lock_guard<mutex> l(entry_lock);
+	entries.erase(name);
+}
+
 } // namespace duckdb

--- a/src/paimon_storage/paimon_table_set.cpp
+++ b/src/paimon_storage/paimon_table_set.cpp
@@ -49,7 +49,11 @@ optional_ptr<CatalogEntry> PaimonTableSet::BuildEntry(ClientContext &context, co
 
 	auto table_schema_result = paimon_catalog.LoadTableSchema(paimon::Identifier(schema.name, table_name));
 	if (!table_schema_result.ok()) {
-		throw IOException(table_schema_result.status().ToString());
+		if (table_schema_result.status().IsNotExist()) {
+			return nullptr;
+		} else {
+			throw IOException(table_schema_result.status().ToString());
+		}
 	}
 	auto table_schema = std::move(table_schema_result).value();
 
@@ -122,6 +126,25 @@ void PaimonTableSet::Scan(ClientContext &context, const std::function<void(Catal
 	for (auto &entry : entries) {
 		callback(*entry.second);
 	}
+}
+
+optional_ptr<CatalogEntry> PaimonTableSet::CreateEntry(CreateTableInfo &info) {
+	lock_guard<mutex> l(entry_lock);
+	auto &catalog = schema.ParentCatalog().Cast<PaimonCatalog>();
+	auto table_entry = make_uniq<PaimonTableEntry>(catalog, schema, info);
+	auto result = entries.emplace(make_pair(info.table, std::move(table_entry)));
+	return result.first->second.get();
+}
+
+optional_ptr<CatalogEntry> PaimonTableSet::RefreshEntry(ClientContext &context, const string &table_name) {
+	lock_guard<mutex> l(entry_lock);
+	entries.erase(table_name);
+	return BuildEntry(context, table_name);
+}
+
+void PaimonTableSet::DropEntry(const string &table_name) {
+	lock_guard<mutex> l(entry_lock);
+	entries.erase(table_name);
 }
 
 } // namespace duckdb

--- a/test/sql/paimon_ddl.test
+++ b/test/sql/paimon_ddl.test
@@ -1,0 +1,122 @@
+# name: test/sql/paimon_ddl.test
+# group: [sql]
+
+require paimon
+
+statement ok
+ATTACH './data' AS pm (TYPE paimon);
+
+# --- cleanup from prior runs ---
+
+statement ok
+DROP TABLE IF EXISTS pm.__test_ddl.t1;
+
+statement ok
+DROP TABLE IF EXISTS pm.__test_ddl.t2;
+
+statement ok
+DROP TABLE IF EXISTS pm.__test_ddl.t3;
+
+statement ok
+DROP TABLE IF EXISTS pm.__test_ddl.t4;
+
+statement ok
+DROP SCHEMA IF EXISTS pm.__test_ddl CASCADE;
+
+# --- CREATE / DROP SCHEMA ---
+
+statement ok
+CREATE SCHEMA pm.__test_ddl;
+
+# duplicate schema without IF NOT EXISTS should error
+statement error
+CREATE SCHEMA pm.__test_ddl;
+----
+already exist
+
+statement ok
+CREATE SCHEMA IF NOT EXISTS pm.__test_ddl;
+
+# --- basic CREATE TABLE ---
+
+statement ok
+CREATE TABLE pm.__test_ddl.t1 (id INTEGER, name VARCHAR);
+
+query IIIIII
+DESCRIBE pm.__test_ddl.t1;
+----
+id	INTEGER	YES	NULL	NULL	NULL
+name	VARCHAR	YES	NULL	NULL	NULL
+
+# --- CREATE TABLE with PRIMARY KEY ---
+
+statement ok
+CREATE TABLE pm.__test_ddl.t2 (id INTEGER PRIMARY KEY, name VARCHAR);
+
+query IIIIII
+DESCRIBE pm.__test_ddl.t2;
+----
+id	INTEGER	YES	NULL	NULL	NULL
+name	VARCHAR	YES	NULL	NULL	NULL
+
+# --- CREATE TABLE IF NOT EXISTS (idempotent) ---
+
+statement ok
+CREATE TABLE pm.__test_ddl.t3 (v INTEGER);
+
+statement ok
+CREATE TABLE IF NOT EXISTS pm.__test_ddl.t3 (v INTEGER);
+
+# --- error: CREATE OR REPLACE not supported ---
+
+statement error
+CREATE OR REPLACE TABLE pm.__test_ddl.t4 (v INTEGER);
+----
+CREATE OR REPLACE TABLE is not supported
+
+# --- error: duplicate CREATE TABLE ---
+
+statement error
+CREATE TABLE pm.__test_ddl.t1 (id INTEGER, name VARCHAR);
+----
+already exist
+
+# --- DROP TABLE ---
+
+statement ok
+DROP TABLE pm.__test_ddl.t1;
+
+statement ok
+DROP TABLE pm.__test_ddl.t2;
+
+statement ok
+DROP TABLE pm.__test_ddl.t3;
+
+# --- DROP TABLE IF EXISTS (no-op) ---
+
+statement ok
+DROP TABLE IF EXISTS pm.__test_ddl.nonexistent;
+
+# --- error: DROP TABLE on non-existent table ---
+
+statement error
+DROP TABLE pm.__test_ddl.nonexistent;
+----
+does not exist
+
+# --- cleanup: DROP SCHEMA ---
+
+statement ok
+DROP SCHEMA pm.__test_ddl;
+
+# duplicate drop without IF EXISTS should error
+statement error
+DROP SCHEMA pm.__test_ddl;
+----
+not exist
+
+statement ok
+DROP SCHEMA IF EXISTS pm.__test_ddl;
+
+statement ok
+DETACH pm;

--- a/test/sql/paimon_ddl.test
+++ b/test/sql/paimon_ddl.test
@@ -21,6 +21,12 @@ statement ok
 DROP TABLE IF EXISTS pm.__test_ddl.t4;
 
 statement ok
+DROP TABLE IF EXISTS pm.__test_ddl.t_partitioned;
+
+statement ok
+DROP TABLE IF EXISTS pm.__test_ddl.t_with_opts;
+
+statement ok
 DROP SCHEMA IF EXISTS pm.__test_ddl CASCADE;
 
 # --- CREATE / DROP SCHEMA ---
@@ -81,6 +87,29 @@ CREATE TABLE pm.__test_ddl.t1 (id INTEGER, name VARCHAR);
 ----
 already exist
 
+# --- CREATE TABLE with PARTITIONED BY ---
+
+statement ok
+CREATE TABLE pm.__test_ddl.t_partitioned (id INTEGER, dt VARCHAR, name VARCHAR, PRIMARY KEY (id, dt)) PARTITIONED BY (dt);
+
+query IIIIII
+DESCRIBE pm.__test_ddl.t_partitioned;
+----
+id	INTEGER	YES	NULL	NULL	NULL
+dt	VARCHAR	YES	NULL	NULL	NULL
+name	VARCHAR	YES	NULL	NULL	NULL
+
+# --- CREATE TABLE with OPTIONS ---
+
+statement ok
+CREATE TABLE pm.__test_ddl.t_with_opts (id INTEGER, name VARCHAR) WITH ('bucket' = '4', 'bucket-key' = 'id');
+
+query IIIIII
+DESCRIBE pm.__test_ddl.t_with_opts;
+----
+id	INTEGER	YES	NULL	NULL	NULL
+name	VARCHAR	YES	NULL	NULL	NULL
+
 # --- DROP TABLE ---
 
 statement ok
@@ -91,6 +120,12 @@ DROP TABLE pm.__test_ddl.t2;
 
 statement ok
 DROP TABLE pm.__test_ddl.t3;
+
+statement ok
+DROP TABLE pm.__test_ddl.t_partitioned;
+
+statement ok
+DROP TABLE pm.__test_ddl.t_with_opts;
 
 # --- DROP TABLE IF EXISTS (no-op) ---
 


### PR DESCRIPTION
Wire the DuckDB catalog entry points to paimon-cpp's DDL APIs so that
users can create and drop Paimon tables and schemas via standard SQL.
The read-only gate is now conditional on the attach access mode instead
of being unconditional.

Table creation converts DuckDB column definitions and primary key
constraints to an Arrow C schema, then delegates to paimon-cpp. Both
schema-level and table-level caches are updated on success to keep the
in-memory catalog consistent.

Add DDL tests that create a temporary schema and tables in the existing
data warehouse, verify structure with DESCRIBE, then drop everything to
leave the test data unchanged.

Also extracts partition key columns and table option key-value pairs
from the CREATE TABLE statement and forwards them to paimon-cpp.
Previously both were passed as empty, so users could not specify
partitioning or configure table properties at creation time. This is a
v1.5-only enhancement since DuckDB 1.5.2 introduced native grammar
support for PARTITIONED BY and WITH clauses.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>