### PR TITLE
feat(write): support CTAS for Paimon tables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ set(EXTENSION_SOURCES
   src/paimon_storage/paimon_scan.cpp
   src/paimon_storage/paimon_snapshots.cpp
   src/paimon_storage/paimon_catalog.cpp
+  src/paimon_storage/paimon_insert.cpp
   src/paimon_storage/paimon_schema_entry.cpp
   src/paimon_storage/paimon_schema_set.cpp
   src/paimon_storage/paimon_table_entry.cpp

--- a/src/include/paimon_catalog.hpp
+++ b/src/include/paimon_catalog.hpp
@@ -93,6 +93,14 @@ public:
 		return attached_options;
 	}
 
+	AccessMode GetAccessMode() const {
+		return access_mode;
+	}
+
+	const string &GetPath() const {
+		return path;
+	}
+
 private:
 	string path;
 	AccessMode access_mode;

--- a/src/include/paimon_insert.hpp
+++ b/src/include/paimon_insert.hpp
@@ -1,0 +1,75 @@
+/*-------------------------------------------------------------------------
+ *
+ * paimon_insert.hpp
+ *
+ * Copyright (c) 2026, Alibaba Group Holding Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * IDENTIFICATION
+ *	  src/include/paimon_insert.hpp
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include "duckdb/execution/physical_operator.hpp"
+#include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
+
+#include <map>
+#include <string>
+
+namespace duckdb {
+
+class SchemaCatalogEntry;
+
+class PhysicalPaimonInsert : public PhysicalOperator {
+public:
+	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::EXTENSION;
+
+	PhysicalPaimonInsert(PhysicalPlan &physical_plan, LogicalOperator &op, SchemaCatalogEntry &schema,
+	                     unique_ptr<BoundCreateTableInfo> info, string table_path, map<string, string> paimon_options,
+	                     idx_t estimated_cardinality);
+
+	SchemaCatalogEntry *schema;
+	unique_ptr<BoundCreateTableInfo> info;
+	string table_path;
+	map<string, string> paimon_options;
+
+public:
+	bool IsSink() const override {
+		return true;
+	}
+	bool ParallelSink() const override {
+		return true;
+	}
+	bool SinkOrderDependent() const override {
+		return false;
+	}
+
+	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
+	unique_ptr<LocalSinkState> GetLocalSinkState(ExecutionContext &context) const override;
+	SinkResultType Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const override;
+	SinkCombineResultType Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const override;
+	SinkFinalizeType Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+	                          OperatorSinkFinalizeInput &input) const override;
+
+	bool IsSource() const override {
+		return true;
+	}
+	SourceResultType GetDataInternal(ExecutionContext &context, DataChunk &chunk,
+	                                 OperatorSourceInput &input) const override;
+};
+
+} // namespace duckdb

--- a/src/paimon_storage/paimon_catalog.cpp
+++ b/src/paimon_storage/paimon_catalog.cpp
@@ -30,9 +30,13 @@
 #include "duckdb/parser/parsed_data/drop_info.hpp"
 #include "duckdb/parser/parsed_data/attach_info.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
+#include "duckdb/planner/operator/logical_create_table.hpp"
 #include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
 
+#include "paimon/catalog/catalog.h"
+
 #include "paimon_catalog.hpp"
+#include "paimon_insert.hpp"
 #include "paimon_schema_entry.hpp"
 #include "paimon_transaction_manager.hpp"
 
@@ -220,9 +224,20 @@ void PaimonCatalog::ScanSchemas(ClientContext &context, std::function<void(Schem
 	_schemas.Scan(context, [&](CatalogEntry &schema) { callback(schema.Cast<PaimonSchemaEntry>()); });
 }
 
-PhysicalOperator &PaimonCatalog::PlanCreateTableAs(ClientContext &, PhysicalPlanGenerator &, LogicalCreateTable &,
-                                                   PhysicalOperator &) {
-	throw NotImplementedException("PlanCreateTableAs not supported yet");
+PhysicalOperator &PaimonCatalog::PlanCreateTableAs(ClientContext &context, PhysicalPlanGenerator &planner,
+                                                   LogicalCreateTable &op, PhysicalOperator &plan) {
+	if (access_mode == AccessMode::READ_ONLY) {
+		throw PermissionException("Cannot write to a read-only Paimon catalog");
+	}
+
+	auto &base = op.info->Base();
+	auto table_path = path + "/" + base.schema + paimon::Catalog::DB_SUFFIX + "/" + base.table;
+	auto paimon_options = GetPaimonOptions(context, path, attached_options);
+
+	auto &insert = planner.Make<PhysicalPaimonInsert>(op, op.schema, std::move(op.info), std::move(table_path),
+	                                                  std::move(paimon_options), 0U);
+	insert.children.push_back(plan);
+	return insert;
 }
 
 PhysicalOperator &PaimonCatalog::PlanInsert(ClientContext &, PhysicalPlanGenerator &, LogicalInsert &,

--- a/src/paimon_storage/paimon_insert.cpp
+++ b/src/paimon_storage/paimon_insert.cpp
@@ -1,0 +1,213 @@
+/*-------------------------------------------------------------------------
+ *
+ * paimon_insert.cpp
+ *
+ * Copyright (c) 2026, Alibaba Group Holding Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * IDENTIFICATION
+ *	  src/paimon_storage/paimon_insert.cpp
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/common/arrow/arrow_converter.hpp"
+
+#include "paimon/commit_context.h"
+#include "paimon/file_store_commit.h"
+#include "paimon/file_store_write.h"
+#include "paimon/record_batch.h"
+#include "paimon/write_context.h"
+
+#include "paimon_insert.hpp"
+#include "paimon_schema_entry.hpp"
+
+#include <atomic>
+#include <mutex>
+
+namespace duckdb {
+
+PhysicalPaimonInsert::PhysicalPaimonInsert(PhysicalPlan &physical_plan, LogicalOperator &op, SchemaCatalogEntry &schema,
+                                           unique_ptr<BoundCreateTableInfo> info, string table_path,
+                                           map<string, string> paimon_options, idx_t estimated_cardinality)
+    : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, {LogicalType::BIGINT}, estimated_cardinality),
+      schema(&schema), info(std::move(info)), table_path(std::move(table_path)),
+      paimon_options(std::move(paimon_options)) {
+}
+
+// ---------------------------------------------------------------------------
+// Sink state
+// ---------------------------------------------------------------------------
+
+struct PaimonInsertGlobalState : public GlobalSinkState {
+	std::mutex lock;
+	std::atomic<int32_t> next_write_id {0};
+	std::vector<std::shared_ptr<paimon::CommitMessage>> all_commit_messages;
+	idx_t insert_count = 0;
+	bool finished = false;
+};
+
+struct PaimonInsertLocalState : public LocalSinkState {
+	std::unique_ptr<paimon::FileStoreWrite> writer;
+	idx_t local_count = 0;
+};
+
+// ---------------------------------------------------------------------------
+// Sink interface
+// ---------------------------------------------------------------------------
+
+unique_ptr<GlobalSinkState> PhysicalPaimonInsert::GetGlobalSinkState(ClientContext &context) const {
+	auto state = make_uniq<PaimonInsertGlobalState>();
+
+	if (info) {
+		auto &paimon_schema = schema->Cast<PaimonSchemaEntry>();
+		auto txn = CatalogTransaction::GetSystemCatalogTransaction(context);
+		paimon_schema.CreateTable(txn, *info);
+	}
+
+	return std::move(state);
+}
+
+unique_ptr<LocalSinkState> PhysicalPaimonInsert::GetLocalSinkState(ExecutionContext &context) const {
+	auto &gstate = sink_state->Cast<PaimonInsertGlobalState>();
+	auto lstate = make_uniq<PaimonInsertLocalState>();
+
+	int32_t write_id = gstate.next_write_id.fetch_add(1);
+
+	paimon::WriteContextBuilder write_builder(table_path, "duckdb");
+	auto write_ctx_result = write_builder.WithWriteId(write_id).SetOptions(paimon_options).Finish();
+	if (!write_ctx_result.ok()) {
+		throw IOException(write_ctx_result.status().ToString());
+	}
+
+	auto writer_result = paimon::FileStoreWrite::Create(std::move(write_ctx_result).value());
+	if (!writer_result.ok()) {
+		throw IOException(writer_result.status().ToString());
+	}
+	lstate->writer = std::move(writer_result).value();
+
+	return std::move(lstate);
+}
+
+SinkResultType PhysicalPaimonInsert::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
+	auto &lstate = input.local_state.Cast<PaimonInsertLocalState>();
+
+	ArrowArray out_array {};
+	auto client_props = context.client.GetClientProperties();
+	ArrowConverter::ToArrowArray(chunk, &out_array, client_props, {});
+	struct ArrowArrayGuard {
+		ArrowArray &array;
+		~ArrowArrayGuard() {
+			if (array.release) {
+				array.release(&array);
+			}
+		}
+	} arrow_guard {out_array};
+
+	paimon::RecordBatchBuilder batch_builder(&out_array);
+	auto batch_result = batch_builder.Finish();
+	if (!batch_result.ok()) {
+		throw IOException(batch_result.status().ToString());
+	}
+
+	auto status = lstate.writer->Write(std::move(batch_result).value());
+	if (!status.ok()) {
+		throw IOException(status.ToString());
+	}
+
+	lstate.local_count += chunk.size();
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+SinkCombineResultType PhysicalPaimonInsert::Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const {
+	auto &gstate = input.global_state.Cast<PaimonInsertGlobalState>();
+	auto &lstate = input.local_state.Cast<PaimonInsertLocalState>();
+
+	if (lstate.local_count == 0) {
+		auto close_status = lstate.writer->Close();
+		if (!close_status.ok()) {
+			throw IOException(close_status.ToString());
+		}
+		lstate.writer.reset();
+		return SinkCombineResultType::FINISHED;
+	}
+
+	auto commit_msgs_result = lstate.writer->PrepareCommit();
+	if (!commit_msgs_result.ok()) {
+		throw IOException(commit_msgs_result.status().ToString());
+	}
+	auto local_messages = std::move(commit_msgs_result).value();
+
+	auto close_status = lstate.writer->Close();
+	if (!close_status.ok()) {
+		throw IOException(close_status.ToString());
+	}
+	lstate.writer.reset();
+
+	lock_guard<std::mutex> guard(gstate.lock);
+	gstate.insert_count += lstate.local_count;
+	for (auto &msg : local_messages) {
+		gstate.all_commit_messages.push_back(std::move(msg));
+	}
+
+	return SinkCombineResultType::FINISHED;
+}
+
+SinkFinalizeType PhysicalPaimonInsert::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                                OperatorSinkFinalizeInput &input) const {
+	auto &gstate = input.global_state.Cast<PaimonInsertGlobalState>();
+
+	if (gstate.all_commit_messages.empty()) {
+		return SinkFinalizeType::READY;
+	}
+
+	paimon::CommitContextBuilder commit_builder(table_path, "duckdb");
+	auto commit_ctx_result = commit_builder.SetOptions(paimon_options).Finish();
+	if (!commit_ctx_result.ok()) {
+		throw IOException(commit_ctx_result.status().ToString());
+	}
+
+	auto committer_result = paimon::FileStoreCommit::Create(std::move(commit_ctx_result).value());
+	if (!committer_result.ok()) {
+		throw IOException(committer_result.status().ToString());
+	}
+
+	auto commit_status = committer_result.value()->Commit(gstate.all_commit_messages);
+	if (!commit_status.ok()) {
+		throw IOException(commit_status.ToString());
+	}
+
+	return SinkFinalizeType::READY;
+}
+
+// ---------------------------------------------------------------------------
+// Source interface (emits row count)
+// ---------------------------------------------------------------------------
+
+SourceResultType PhysicalPaimonInsert::GetDataInternal(ExecutionContext &context, DataChunk &chunk,
+                                                       OperatorSourceInput &input) const {
+	auto &gstate = sink_state->Cast<PaimonInsertGlobalState>();
+	if (gstate.finished) {
+		return SourceResultType::FINISHED;
+	}
+
+	chunk.SetCardinality(1);
+	chunk.SetValue(0, 0, Value::BIGINT(gstate.insert_count));
+	gstate.finished = true;
+
+	return SourceResultType::HAVE_MORE_OUTPUT;
+}
+
+} // namespace duckdb

--- a/test/sql/paimon_write.test
+++ b/test/sql/paimon_write.test
@@ -1,0 +1,105 @@
+# name: test/sql/paimon_write.test
+# group: [sql]
+
+require paimon
+
+statement ok
+ATTACH './data' AS pm (TYPE paimon);
+
+# --- cleanup from prior runs ---
+
+statement ok
+DROP TABLE IF EXISTS pm.__test_write.t_ctas_small;
+
+statement ok
+DROP TABLE IF EXISTS pm.__test_write.t_ctas_large;
+
+statement ok
+DROP SCHEMA IF EXISTS pm.__test_write CASCADE;
+
+# --- setup ---
+
+statement ok
+CREATE SCHEMA pm.__test_write;
+
+# --- CTAS with multiple types (small) ---
+
+statement ok
+CREATE TABLE pm.__test_write.t_ctas_small AS
+    SELECT * FROM (VALUES
+        (1, 100000000000::BIGINT, 'hello', 3.14::FLOAT, 2.718281828::DOUBLE, TRUE, '2025-01-15'::DATE, '2025-01-15 10:30:00'::TIMESTAMP),
+        (2, 200000000000::BIGINT, 'world', 1.41::FLOAT, 3.141592653::DOUBLE, FALSE, '2025-06-30'::DATE, '2025-06-30 23:59:59'::TIMESTAMP),
+        (3, NULL, NULL, NULL, NULL, TRUE, NULL, NULL)
+    ) t(id, big_id, name, score_f, score_d, flag, dt, ts);
+
+query IITRRTTT
+SELECT * FROM pm.__test_write.t_ctas_small ORDER BY id;
+----
+1	100000000000	hello	3.14	2.718281828	true	2025-01-15	2025-01-15 10:30:00
+2	200000000000	world	1.41	3.141592653	false	2025-06-30	2025-06-30 23:59:59
+3	NULL	NULL	NULL	NULL	true	NULL	NULL
+
+# --- CTAS duplicate table should fail ---
+
+statement error
+CREATE TABLE pm.__test_write.t_ctas_small AS SELECT 1 AS id;
+----
+already exist
+
+# --- CTAS with large dataset (exercises parallel sink) ---
+
+statement ok
+CREATE TABLE pm.__test_write.t_ctas_large AS
+    SELECT
+        i AS id,
+        i * 1000000000::BIGINT AS big_id,
+        'val_' || i::VARCHAR AS name,
+        (i * 0.1)::FLOAT AS score_f,
+        i * 0.001 AS score_d,
+        (i % 2 = 0) AS flag,
+        ('2020-01-01'::DATE + (i % 1000)::INTEGER)::DATE AS dt,
+        ('2020-01-01 00:00:00'::TIMESTAMP + INTERVAL (i) SECOND) AS ts
+    FROM generate_series(1, 100000) t(i);
+
+query I
+SELECT count(*) FROM pm.__test_write.t_ctas_large;
+----
+100000
+
+query II
+SELECT min(id), max(id) FROM pm.__test_write.t_ctas_large;
+----
+1	100000
+
+# --- CTAS into read-only catalog should fail ---
+
+statement ok
+DETACH pm;
+
+statement ok
+ATTACH './data' AS pm_ro (TYPE paimon, READ_ONLY);
+
+statement error
+CREATE TABLE pm_ro.__test_write.t_fail AS SELECT 1 AS id;
+----
+read-only
+
+statement ok
+DETACH pm_ro;
+
+# --- cleanup ---
+
+statement ok
+ATTACH './data' AS pm (TYPE paimon);
+
+statement ok
+DROP TABLE pm.__test_write.t_ctas_small;
+
+statement ok
+DROP TABLE pm.__test_write.t_ctas_large;
+
+statement ok
+DROP SCHEMA pm.__test_write;
+
+statement ok
+DETACH pm;


### PR DESCRIPTION
Implement CREATE TABLE AS SELECT for Paimon tables with parallel write
support. Each DuckDB sink thread gets its own FileStoreWrite instance
(distinguished by write_id), writes data independently via Arrow
conversion, then merges commit messages under a mutex before a single
atomic Paimon commit.

Read-only catalogs are checked upfront and rejected with a clear error.
The ArrowArray lifecycle is managed via an RAII guard to prevent leaks
on any error path.