### PR TITLE
feat(build): support macOS (arm64) builds

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -19,7 +19,7 @@ jobs:
       duckdb_version: v1.5.2
       ci_tools_version: v1.5.2
       extension_name: paimon
-      exclude_archs: 'linux_amd64_musl;osx_amd64;osx_arm64;windows_amd64;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads'
+      exclude_archs: 'linux_amd64_musl;osx_amd64;windows_amd64;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads'
 
   code-quality-check:
     name: Code Quality Check

--- a/.github/workflows/release-bundle.yml
+++ b/.github/workflows/release-bundle.yml
@@ -29,6 +29,8 @@ jobs:
             runner: ubuntu-22.04
           - bundle_arch: linux-arm64
             runner: ubuntu-22.04-arm
+          - bundle_arch: osx-arm64
+            runner: macos-14
     steps:
       - name: Checkout source
         uses: actions/checkout@v6
@@ -56,7 +58,11 @@ jobs:
       - name: Build extension (release)
         shell: bash
         run: |
-          GEN=ninja make
+          if command -v ninja &>/dev/null; then
+            GEN=ninja make
+          else
+            make
+          fi
 
       - name: Package release bundle
         id: package
@@ -73,14 +79,22 @@ jobs:
           mkdir -p "${STAGE_DIR}"
 
           cp "${EXT_DIR}/paimon.duckdb_extension" "${STAGE_DIR}/"
-          cp "${EXT_DIR}"/libpaimon*.so* "${STAGE_DIR}/"
-          cp "${EXT_DIR}"/libjindosdk_c.so* "${STAGE_DIR}/"
+          case "${{ matrix.bundle_arch }}" in
+            linux-*) LIB_EXT="so" ;;
+            osx-*)   LIB_EXT="dylib" ;;
+          esac
+          cp "${EXT_DIR}"/libpaimon*."${LIB_EXT}"* "${STAGE_DIR}/"
+          cp "${EXT_DIR}"/libjindosdk_c*."${LIB_EXT}"* "${STAGE_DIR}/"
 
           cp LICENSE "${STAGE_DIR}/LICENSE"
           cp README.md "${STAGE_DIR}/README.md"
 
           tar -C dist -czf "dist/${PKG_NAME}.tar.gz" "${PKG_NAME}"
-          sha256sum "dist/${PKG_NAME}.tar.gz" > "dist/${PKG_NAME}.tar.gz.sha256"
+          if command -v sha256sum &>/dev/null; then
+            sha256sum "dist/${PKG_NAME}.tar.gz" > "dist/${PKG_NAME}.tar.gz.sha256"
+          else
+            shasum -a 256 "dist/${PKG_NAME}.tar.gz" > "dist/${PKG_NAME}.tar.gz.sha256"
+          fi
 
           echo "archive=dist/${PKG_NAME}.tar.gz" >> "${GITHUB_OUTPUT}"
           echo "checksum=dist/${PKG_NAME}.tar.gz.sha256" >> "${GITHUB_OUTPUT}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.17)
 
 # Set extension name here
 set(TARGET_NAME paimon)
@@ -15,6 +15,20 @@ include_directories(src/include)
 # Import paimon-cpp as a subproject
 include(ExternalProject)
 
+# JindoSDK: the installed filename differs by platform, but we always bundle
+# using the short name that matches the dylib's install_name.
+file(STRINGS third_party/paimon-cpp/third_party/versions.txt
+     _jindosdk_ver REGEX "^PAIMON_JINDOSDK_C_BUILD_VERSION=")
+string(REGEX REPLACE ".*=" "" _jindosdk_ver "${_jindosdk_ver}")
+string(REGEX REPLACE "([0-9]+)\\..*" "\\1" _jindosdk_major "${_jindosdk_ver}")
+if(APPLE)
+  set(JINDOSDK_C_INSTALLED_NAME "libjindosdk_c.${_jindosdk_ver}.dylib")
+  set(JINDOSDK_C_RUNTIME_NAME "libjindosdk_c.${_jindosdk_major}.dylib")
+else()
+  set(JINDOSDK_C_INSTALLED_NAME "libjindosdk_c.so")
+  set(JINDOSDK_C_RUNTIME_NAME "libjindosdk_c.so.${_jindosdk_major}")
+endif()
+
 set(PAIMON_CPP_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/paimon-cpp)
 set(PAIMON_CPP_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/paimon-cpp-install)
 set(PAIMON_CPP_INCLUDE ${PAIMON_CPP_PREFIX}/include)
@@ -23,8 +37,7 @@ file(MAKE_DIRECTORY ${PAIMON_CPP_INCLUDE})
 
 set(PAIMON_CPP_PATCHES
   ${CMAKE_CURRENT_SOURCE_DIR}/patches/paimon-cpp-install-arrow-headers.patch
-  ${CMAKE_CURRENT_SOURCE_DIR}/patches/paimon-cpp-link-arrow-brotli-libs.patch
-  ${CMAKE_CURRENT_SOURCE_DIR}/patches/paimon-cpp-disable-glog-unwind.patch)
+  ${CMAKE_CURRENT_SOURCE_DIR}/patches/paimon-cpp-macos-ndebug-for-checked-cast.patch)
 
 # Build patch command: apply each patch idempotently
 set(PAIMON_CPP_PATCH_SCRIPT "")
@@ -43,6 +56,7 @@ ExternalProject_Add(paimon_cpp_ep
     -DCMAKE_INSTALL_PREFIX=${PAIMON_CPP_PREFIX}
     -DCMAKE_INSTALL_LIBDIR=lib64
     -DLIBUNWIND_LIBRARY=FALSE
+    -DPAIMON_DEPENDENCY_SOURCE=BUNDLED
     -DPAIMON_BUILD_TESTS=OFF
     -DPAIMON_BUILD_SHARED=ON
     -DPAIMON_BUILD_STATIC=OFF
@@ -52,15 +66,28 @@ ExternalProject_Add(paimon_cpp_ep
     -DPAIMON_ENABLE_LUMINA=OFF
     -DPAIMON_ENABLE_LUCENE=OFF
   BUILD_BYPRODUCTS
-    ${PAIMON_CPP_LIB}/libpaimon.so
-    ${PAIMON_CPP_LIB}/libpaimon_local_file_system.so
-    ${PAIMON_CPP_LIB}/libpaimon_jindo_file_system.so
-    ${PAIMON_CPP_LIB}/libjindosdk_c.so
-    ${PAIMON_CPP_LIB}/libpaimon_parquet_file_format.so
-    ${PAIMON_CPP_LIB}/libpaimon_orc_file_format.so
-    ${PAIMON_CPP_LIB}/libpaimon_avro_file_format.so
-    ${PAIMON_CPP_LIB}/libpaimon_blob_file_format.so
+    ${PAIMON_CPP_LIB}/libpaimon${CMAKE_SHARED_LIBRARY_SUFFIX}
+    ${PAIMON_CPP_LIB}/libpaimon_local_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
+    ${PAIMON_CPP_LIB}/libpaimon_jindo_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
+    ${PAIMON_CPP_LIB}/${JINDOSDK_C_INSTALLED_NAME}
+    ${PAIMON_CPP_LIB}/libpaimon_parquet_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}
+    ${PAIMON_CPP_LIB}/libpaimon_orc_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}
+    ${PAIMON_CPP_LIB}/libpaimon_avro_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}
+    ${PAIMON_CPP_LIB}/libpaimon_blob_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}
 )
+
+# On macOS, paimon-cpp installs the JindoSDK dylib with a versioned filename
+# (e.g. libjindosdk_c.6.10.2.dylib) but its install_name uses the short
+# version (libjindosdk_c.6.dylib). Add a post-install step to provide the
+# short-named copy that runtime lookup expects.
+if(APPLE)
+  ExternalProject_Add_Step(paimon_cpp_ep jindosdk_short_name
+    DEPENDEES install
+    BYPRODUCTS ${PAIMON_CPP_LIB}/${JINDOSDK_C_RUNTIME_NAME}
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      ${PAIMON_CPP_LIB}/${JINDOSDK_C_INSTALLED_NAME}
+      ${PAIMON_CPP_LIB}/${JINDOSDK_C_RUNTIME_NAME})
+endif()
 
 # Extension sources
 set(EXTENSION_SOURCES
@@ -90,30 +117,38 @@ add_dependencies(${TARGET_NAME}_loadable_extension paimon_cpp_ep)
 
 # Link with paimon-cpp
 set(PAIMON_CPP_LIBS
-  ${PAIMON_CPP_LIB}/libpaimon.so
-  -Wl,--no-as-needed
-  ${PAIMON_CPP_LIB}/libpaimon_local_file_system.so
-  ${PAIMON_CPP_LIB}/libpaimon_jindo_file_system.so
-  ${PAIMON_CPP_LIB}/libjindosdk_c.so
-  ${PAIMON_CPP_LIB}/libpaimon_parquet_file_format.so
-  ${PAIMON_CPP_LIB}/libpaimon_orc_file_format.so
-  ${PAIMON_CPP_LIB}/libpaimon_avro_file_format.so
-  ${PAIMON_CPP_LIB}/libpaimon_blob_file_format.so
-  -Wl,--as-needed
+  ${PAIMON_CPP_LIB}/libpaimon${CMAKE_SHARED_LIBRARY_SUFFIX}
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:-Wl,--no-as-needed>
+  ${PAIMON_CPP_LIB}/libpaimon_local_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
+  ${PAIMON_CPP_LIB}/libpaimon_jindo_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
+  ${PAIMON_CPP_LIB}/${JINDOSDK_C_INSTALLED_NAME}
+  ${PAIMON_CPP_LIB}/libpaimon_parquet_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}
+  ${PAIMON_CPP_LIB}/libpaimon_orc_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}
+  ${PAIMON_CPP_LIB}/libpaimon_avro_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}
+  ${PAIMON_CPP_LIB}/libpaimon_blob_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:-Wl,--as-needed>
 )
 target_link_libraries(${EXTENSION_NAME} ${PAIMON_CPP_LIBS})
 target_link_libraries(${TARGET_NAME}_loadable_extension ${PAIMON_CPP_LIBS})
 
+if(APPLE)
+  # Propagate rpath so unittest/shell can find paimon-cpp shared libraries.
+  target_link_options(${EXTENSION_NAME} INTERFACE "LINKER:-rpath,${PAIMON_CPP_LIB}")
+  set(PAIMON_RPATH "@loader_path")
+else()
+  set(PAIMON_RPATH "\$ORIGIN")
+endif()
+
 # Bundle paimon-cpp runtime dependencies next to paimon.duckdb_extension.
 set(PAIMON_CPP_RUNTIME_BUNDLE_LIBS
-  ${PAIMON_CPP_LIB}/libpaimon.so
-  ${PAIMON_CPP_LIB}/libpaimon_local_file_system.so
-  ${PAIMON_CPP_LIB}/libpaimon_jindo_file_system.so
-  ${PAIMON_CPP_LIB}/libjindosdk_c.so.6
-  ${PAIMON_CPP_LIB}/libpaimon_parquet_file_format.so
-  ${PAIMON_CPP_LIB}/libpaimon_orc_file_format.so
-  ${PAIMON_CPP_LIB}/libpaimon_avro_file_format.so
-  ${PAIMON_CPP_LIB}/libpaimon_blob_file_format.so
+  ${PAIMON_CPP_LIB}/libpaimon${CMAKE_SHARED_LIBRARY_SUFFIX}
+  ${PAIMON_CPP_LIB}/libpaimon_local_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
+  ${PAIMON_CPP_LIB}/libpaimon_jindo_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
+  ${PAIMON_CPP_LIB}/${JINDOSDK_C_RUNTIME_NAME}
+  ${PAIMON_CPP_LIB}/libpaimon_parquet_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}
+  ${PAIMON_CPP_LIB}/libpaimon_orc_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}
+  ${PAIMON_CPP_LIB}/libpaimon_avro_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}
+  ${PAIMON_CPP_LIB}/libpaimon_blob_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}
 )
 foreach(lib IN LISTS PAIMON_CPP_RUNTIME_BUNDLE_LIBS)
   add_custom_command(
@@ -124,11 +159,9 @@ foreach(lib IN LISTS PAIMON_CPP_RUNTIME_BUNDLE_LIBS)
       $<TARGET_FILE_DIR:${TARGET_NAME}_loadable_extension>
   )
 endforeach()
-
-# Make runtime library lookup relocatable for the shipped loadable extension.
 set_target_properties(${TARGET_NAME}_loadable_extension PROPERTIES
-  BUILD_RPATH "\$ORIGIN"
-  INSTALL_RPATH "\$ORIGIN"
+  BUILD_RPATH "${PAIMON_RPATH}"
+  INSTALL_RPATH "${PAIMON_RPATH}"
   BUILD_WITH_INSTALL_RPATH ON
   INSTALL_RPATH_USE_LINK_PATH OFF
 )

--- a/patches/paimon-cpp-install-arrow-headers.patch
+++ b/patches/paimon-cpp-install-arrow-headers.patch
@@ -1,8 +1,7 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 8a81fbb..93234b3 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -310,6 +310,11 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
+@@ -321,6 +321,11 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
          DESTINATION "include"
          FILES_MATCHING
          PATTERN "*.h")
@@ -11,6 +10,6 @@ index 8a81fbb..93234b3 100644
 +        FILES_MATCHING
 +        PATTERN "*.h"
 +        PATTERN "*.hpp")
- 
+
  set(CMAKE_CXX_VISIBILITY_PRESET hidden)
  set(CMAKE_C_VISIBILITY_PRESET hidden)

--- a/patches/paimon-cpp-macos-ndebug-for-checked-cast.patch
+++ b/patches/paimon-cpp-macos-ndebug-for-checked-cast.patch
@@ -1,0 +1,19 @@
+diff --git a/cmake_modules/BuildUtils.cmake b/cmake_modules/BuildUtils.cmake
+index ed27ed7..1a4e79c 100644
+--- a/cmake_modules/BuildUtils.cmake
++++ b/cmake_modules/BuildUtils.cmake
+@@ -176,7 +176,13 @@ function(add_paimon_lib LIB_NAME)
+         target_link_libraries(${LIB_NAME}_shared
+                               PUBLIC "$<BUILD_INTERFACE:paimon_sanitizer_flags>")
+ 
+-        if(NOT APPLE)
++        if(APPLE)
++            # Arrow's checked_cast uses dynamic_cast in Debug builds, which
++            # fails across dylib boundaries on macOS due to duplicate RTTI
++            # from static Arrow archives.  Define NDEBUG so checked_cast
++            # falls back to static_cast (same as Release mode).
++            target_compile_definitions(${LIB_NAME}_objlib PRIVATE $<$<CONFIG:Debug>:NDEBUG>)
++        else()
+             target_link_options(${LIB_NAME}_shared
+                                 PRIVATE
+                                 -Wl,--exclude-libs,ALL


### PR DESCRIPTION
This PR adds macOS (arm64) build support for duckdb-paimon.

## Changes

- **paimon-cpp submodule**: Updated to a version that includes macOS support for both the core library and JindoSDK (aarch64).
- **CMakeLists.txt**: Adapted for cross-platform builds:
  - Use `CMAKE_SHARED_LIBRARY_SUFFIX` instead of hardcoded `.so`.
  - Handle macOS rpath with `@loader_path` (vs `$ORIGIN` on Linux).
  - Read JindoSDK version from `versions.txt` and rename the versioned dylib to the short name matching its `install_name`.
  - Use generator expressions for GNU-ld-specific linker flags (`--no-as-needed`).
  - Add `PAIMON_DEPENDENCY_SOURCE=BUNDLED` so all dependencies are built from source.
- **Patches**:
  - Removed two patches already merged into the new paimon-cpp version (glog unwind, brotli linking).
  - Updated the Arrow headers install patch for the new paimon-cpp line numbers.
  - Added a new patch to define `NDEBUG` on macOS plugin dylibs, so Arrow's `checked_cast` uses `static_cast` instead of `dynamic_cast` — avoiding RTTI mismatches across dylib boundaries from duplicated static Arrow archives.
- **CI**: Enabled `osx_arm64` in both the distribution pipeline and the release bundle workflow, with platform-aware packaging (ninja fallback, `shasum` compatibility, `.dylib` glob).

## Test

- Local: Debug and Release builds pass all 9 test cases on macOS arm64 (Apple Silicon).
- CI: Linux (amd64, arm64) and macOS (arm64) all green.
- Release bundle: Downloaded from GitHub Release, loaded into a standalone DuckDB v1.5.2 with `LOAD`, and verified all test paths (scan, avro manifest, snapshots, type mapping, time travel, predicate pushdown, CTAS, INSERT, DDL).