### PR TITLE
feat(scan): push predicates into scan planning

### DIFF
--- a/src/paimon_storage/paimon_scan.cpp
+++ b/src/paimon_storage/paimon_scan.cpp
@@ -622,7 +622,8 @@ static unique_ptr<GlobalTableFunctionState> PaimonScanInitGlobal(ClientContext &
 	// construct the scanner
 	paimon::ScanContextBuilder scan_context_builder(path);
 
-	auto scan_context_result = scan_context_builder.SetOptions(bind.paimon_options).Finish();
+	auto scan_context_result =
+	    scan_context_builder.SetOptions(bind.paimon_options).SetPredicate(bind.predicates).Finish();
 	if (!scan_context_result.ok()) {
 		throw IOException(scan_context_result.status().ToString());
 	}


### PR DESCRIPTION
## Summary

Pass converted scan predicates into Paimon scan planning so file-level pruning can exclude irrelevant splits before reader setup.

Keep the reader predicate path as the finer-grained filtering stage for splits that remain after planning.

## Validation

- `make debug`
- `./build/debug/test/unittest test/sql/predicate_pushdown.test`