### PR TITLE
fix(build): suppress -Wglobal-constructors in paimon-cpp debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,8 @@ file(MAKE_DIRECTORY ${PAIMON_CPP_INCLUDE})
 
 set(PAIMON_CPP_PATCHES
   ${CMAKE_CURRENT_SOURCE_DIR}/patches/paimon-cpp-install-arrow-headers.patch
-  ${CMAKE_CURRENT_SOURCE_DIR}/patches/paimon-cpp-macos-ndebug-for-checked-cast.patch)
+  ${CMAKE_CURRENT_SOURCE_DIR}/patches/paimon-cpp-macos-ndebug-for-checked-cast.patch
+  ${CMAKE_CURRENT_SOURCE_DIR}/patches/paimon-cpp-disable-global-constructors-warning.patch)
 
 # Build patch command: apply each patch idempotently
 set(PAIMON_CPP_PATCH_SCRIPT "")

--- a/patches/paimon-cpp-disable-global-constructors-warning.patch
+++ b/patches/paimon-cpp-disable-global-constructors-warning.patch
@@ -1,0 +1,12 @@
+diff --git a/cmake_modules/SetupCxxFlags.cmake b/cmake_modules/SetupCxxFlags.cmake
+index 4df2f56..884f065 100644
+--- a/cmake_modules/SetupCxxFlags.cmake
++++ b/cmake_modules/SetupCxxFlags.cmake
+@@ -75,7 +75,6 @@ if("${BUILD_WARNING_LEVEL}" STREQUAL "CHECKIN")
+         set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wall")
+         set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wextra")
+         set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wdocumentation")
+-        set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wglobal-constructors")
+         set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-missing-braces")
+         set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-unused-parameter")
+         set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-unknown-warning-option")


### PR DESCRIPTION
## Summary

- On macOS with Clang, debug builds (`make debug`) fail because paimon-cpp enables `-Wglobal-constructors -Werror` under its `CHECKIN` warning level
- The `REGISTER_PAIMON_FACTORY` macro uses `__attribute__((constructor))`, which triggers this warning on every factory registration call site
- This patch removes `-Wglobal-constructors` from paimon-cpp's `SetupCxxFlags.cmake` via the existing patch mechanism, fixing the debug build on macOS

## Test plan

- [x] `make debug` passes from clean state (submodule reset + build dir removed)
- [x] `make` (release) still passes from clean state
- [x] Control test: without the patch, `make debug` fails with the expected `-Wglobal-constructors` errors