### PR TITLE
feat(scan): support partition filter pushdown for DuckDB 1.4

### DIFF
--- a/src/include/paimon_insert.hpp
+++ b/src/include/paimon_insert.hpp
@@ -40,12 +40,13 @@ public:
 
 	PhysicalPaimonInsert(PhysicalPlan &physical_plan, LogicalOperator &op, SchemaCatalogEntry &schema,
 	                     unique_ptr<BoundCreateTableInfo> info, string table_path, map<string, string> paimon_options,
-	                     idx_t estimated_cardinality);
+	                     vector<string> part_keys, idx_t estimated_cardinality);
 
 	SchemaCatalogEntry *schema;
 	unique_ptr<BoundCreateTableInfo> info;
 	string table_path;
 	map<string, string> paimon_options;
+	vector<string> part_keys;
 
 public:
 	bool IsSink() const override {

--- a/src/paimon_storage/paimon_catalog.cpp
+++ b/src/paimon_storage/paimon_catalog.cpp
@@ -36,6 +36,7 @@
 #include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
 
 #include "paimon/catalog/catalog.h"
+#include "paimon/schema/schema.h"
 
 #include "paimon_catalog.hpp"
 #include "paimon_insert.hpp"
@@ -236,8 +237,10 @@ PhysicalOperator &PaimonCatalog::PlanCreateTableAs(ClientContext &context, Physi
 	auto table_path = path + "/" + base.schema + paimon::Catalog::DB_SUFFIX + "/" + base.table;
 	auto paimon_options = GetPaimonOptions(context, path, attached_options);
 
+	vector<string> part_keys;
+
 	auto &insert = planner.Make<PhysicalPaimonInsert>(op, op.schema, std::move(op.info), std::move(table_path),
-	                                                  std::move(paimon_options), 0U);
+	                                                  std::move(paimon_options), std::move(part_keys), 0U);
 	insert.children.push_back(plan);
 	return insert;
 }
@@ -252,12 +255,23 @@ PhysicalOperator &PaimonCatalog::PlanInsert(ClientContext &context, PhysicalPlan
 	auto table_path = path + "/" + table.schema.name + paimon::Catalog::DB_SUFFIX + "/" + table.name;
 	auto paimon_options = GetPaimonOptions(context, path, attached_options);
 
+	vector<string> part_keys;
+	auto schema_result = paimon_catalog->LoadTableSchema(paimon::Identifier(table.schema.name, table.name));
+	if (!schema_result.ok()) {
+		throw IOException(schema_result.status().ToString());
+	}
+	auto data_schema = std::dynamic_pointer_cast<paimon::DataSchema>(schema_result.value());
+	if (data_schema) {
+		auto &schema_part_keys = data_schema->PartitionKeys();
+		part_keys.assign(schema_part_keys.begin(), schema_part_keys.end());
+	}
+
 	if (plan && !op.column_index_map.empty()) {
 		plan = planner.ResolveDefaultsProjection(op, *plan);
 	}
 
 	auto &insert = planner.Make<PhysicalPaimonInsert>(op, table.schema, nullptr, std::move(table_path),
-	                                                  std::move(paimon_options), 0U);
+	                                                  std::move(paimon_options), std::move(part_keys), 0U);
 	if (plan) {
 		insert.children.push_back(*plan);
 	}

--- a/src/paimon_storage/paimon_insert.cpp
+++ b/src/paimon_storage/paimon_insert.cpp
@@ -26,12 +26,16 @@
 #include "duckdb/common/arrow/arrow_converter.hpp"
 #include "duckdb/main/client_context.hpp"
 
+#include "paimon/catalog/catalog.h"
+#include "paimon/catalog/identifier.h"
 #include "paimon/commit_context.h"
 #include "paimon/file_store_commit.h"
 #include "paimon/file_store_write.h"
 #include "paimon/record_batch.h"
+#include "paimon/schema/schema.h"
 #include "paimon/write_context.h"
 
+#include "paimon_catalog.hpp"
 #include "paimon_insert.hpp"
 #include "paimon_schema_entry.hpp"
 
@@ -42,10 +46,11 @@ namespace duckdb {
 
 PhysicalPaimonInsert::PhysicalPaimonInsert(PhysicalPlan &physical_plan, LogicalOperator &op, SchemaCatalogEntry &schema,
                                            unique_ptr<BoundCreateTableInfo> info, string table_path,
-                                           map<string, string> paimon_options, idx_t estimated_cardinality)
+                                           map<string, string> paimon_options, vector<string> part_keys,
+                                           idx_t estimated_cardinality)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, {LogicalType::BIGINT}, estimated_cardinality),
       schema(&schema), info(std::move(info)), table_path(std::move(table_path)),
-      paimon_options(std::move(paimon_options)) {
+      paimon_options(std::move(paimon_options)), part_keys(std::move(part_keys)) {
 }
 
 // ---------------------------------------------------------------------------
@@ -58,6 +63,10 @@ struct PaimonInsertGlobalState : public GlobalSinkState {
 	std::vector<std::shared_ptr<paimon::CommitMessage>> all_commit_messages;
 	idx_t insert_count = 0;
 	bool finished = false;
+
+	vector<string> part_key_names;
+	vector<idx_t> part_col_idxs;
+	string null_part_name = "__DEFAULT_PARTITION__";
 };
 
 struct PaimonInsertLocalState : public LocalSinkState {
@@ -76,6 +85,45 @@ unique_ptr<GlobalSinkState> PhysicalPaimonInsert::GetGlobalSinkState(ClientConte
 		auto &paimon_schema = schema->Cast<PaimonSchemaEntry>();
 		auto txn = CatalogTransaction::GetSystemCatalogTransaction(context);
 		paimon_schema.CreateTable(txn, *info);
+	}
+
+	if (!part_keys.empty()) {
+		auto &paimon_catalog = schema->catalog.Cast<PaimonCatalog>();
+		auto &catalog = paimon_catalog.GetPaimonCatalog();
+		auto schema_name = info ? info->Base().schema : schema->name;
+		auto table_name = info ? info->Base().table : string();
+
+		if (table_name.empty()) {
+			auto last_slash = table_path.rfind('/');
+			table_name = (last_slash != string::npos) ? table_path.substr(last_slash + 1) : table_path;
+		}
+
+		auto schema_result = catalog.LoadTableSchema(paimon::Identifier(schema_name, table_name));
+		if (!schema_result.ok()) {
+			throw IOException(schema_result.status().ToString());
+		}
+
+		auto table_schema = schema_result.value();
+		auto data_schema = std::dynamic_pointer_cast<paimon::DataSchema>(table_schema);
+		if (!data_schema) {
+			throw IOException("Failed to resolve Paimon data schema for partitioned insert");
+		}
+
+		auto &table_options = data_schema->Options();
+		auto default_name = table_options.find(paimon::Options::PARTITION_DEFAULT_NAME);
+		if (default_name != table_options.end()) {
+			state->null_part_name = default_name->second;
+		}
+
+		auto field_names = table_schema->FieldNames();
+		state->part_key_names = part_keys;
+		for (auto &part_key : part_keys) {
+			auto it = std::find(field_names.begin(), field_names.end(), part_key);
+			if (it == field_names.end()) {
+				throw IOException("Partition key \"%s\" not found in Paimon table schema", part_key);
+			}
+			state->part_col_idxs.push_back(std::distance(field_names.begin(), it));
+		}
 	}
 
 	return std::move(state);
@@ -102,22 +150,16 @@ unique_ptr<LocalSinkState> PhysicalPaimonInsert::GetLocalSinkState(ExecutionCont
 	return std::move(lstate);
 }
 
-SinkResultType PhysicalPaimonInsert::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
-	auto &lstate = input.local_state.Cast<PaimonInsertLocalState>();
+static void WriteChunkWithPartition(PaimonInsertLocalState &lstate, DataChunk &chunk, ClientContext &client,
+                                    const std::map<string, string> &partition) {
+	ArrowArrayWrapper arrow_wrapper;
+	auto client_props = client.GetClientProperties();
+	ArrowConverter::ToArrowArray(chunk, &arrow_wrapper.arrow_array, client_props, {});
 
-	ArrowArray out_array {};
-	auto client_props = context.client.GetClientProperties();
-	ArrowConverter::ToArrowArray(chunk, &out_array, client_props, {});
-	struct ArrowArrayGuard {
-		ArrowArray &array;
-		~ArrowArrayGuard() {
-			if (array.release) {
-				array.release(&array);
-			}
-		}
-	} arrow_guard {out_array};
-
-	paimon::RecordBatchBuilder batch_builder(&out_array);
+	paimon::RecordBatchBuilder batch_builder(&arrow_wrapper.arrow_array);
+	if (!partition.empty()) {
+		batch_builder.SetPartition(partition).SetBucket(0);
+	}
 	auto batch_result = batch_builder.Finish();
 	if (!batch_result.ok()) {
 		throw IOException(batch_result.status().ToString());
@@ -127,8 +169,66 @@ SinkResultType PhysicalPaimonInsert::Sink(ExecutionContext &context, DataChunk &
 	if (!status.ok()) {
 		throw IOException(status.ToString());
 	}
+}
 
-	lstate.local_count += chunk.size();
+SinkResultType PhysicalPaimonInsert::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
+	auto &gstate = input.global_state.Cast<PaimonInsertGlobalState>();
+	auto &lstate = input.local_state.Cast<PaimonInsertLocalState>();
+
+	if (gstate.part_col_idxs.empty()) {
+		WriteChunkWithPartition(lstate, chunk, context.client, {});
+		lstate.local_count += chunk.size();
+		return SinkResultType::NEED_MORE_INPUT;
+	}
+
+	auto num_rows = chunk.size();
+	auto &part_idxs = gstate.part_col_idxs;
+	auto &part_names = gstate.part_key_names;
+	D_ASSERT(part_idxs.size() == part_names.size());
+
+	vector<UnifiedVectorFormat> part_formats(part_idxs.size());
+	for (idx_t i = 0; i < part_idxs.size(); i++) {
+		chunk.data[part_idxs[i]].ToUnifiedFormat(num_rows, part_formats[i]);
+	}
+
+	std::map<std::vector<string>, vector<idx_t>> partition_groups;
+	for (idx_t row = 0; row < num_rows; row++) {
+		std::vector<string> key;
+		key.reserve(part_idxs.size());
+		for (idx_t i = 0; i < part_idxs.size(); i++) {
+			auto idx = part_formats[i].sel->get_index(row);
+			if (!part_formats[i].validity.RowIsValid(idx)) {
+				key.push_back(gstate.null_part_name);
+			} else {
+				key.push_back(chunk.GetValue(part_idxs[i], row).ToString());
+			}
+		}
+		auto entry = partition_groups.emplace(std::move(key), vector<idx_t>());
+		entry.first->second.push_back(row);
+	}
+
+	for (auto &entry : partition_groups) {
+		auto &key_values = entry.first;
+		auto &row_indices = entry.second;
+
+		std::map<string, string> partition;
+		for (idx_t i = 0; i < part_names.size(); i++) {
+			partition[part_names[i]] = key_values[i];
+		}
+
+		SelectionVector sel(row_indices.size());
+		for (idx_t i = 0; i < row_indices.size(); i++) {
+			sel.set_index(i, row_indices[i]);
+		}
+
+		DataChunk sub_chunk;
+		sub_chunk.Initialize(Allocator::DefaultAllocator(), chunk.GetTypes());
+		sub_chunk.Slice(chunk, sel, row_indices.size());
+
+		WriteChunkWithPartition(lstate, sub_chunk, context.client, partition);
+	}
+
+	lstate.local_count += num_rows;
 	return SinkResultType::NEED_MORE_INPUT;
 }
 

--- a/src/paimon_storage/paimon_scan.cpp
+++ b/src/paimon_storage/paimon_scan.cpp
@@ -58,6 +58,12 @@ public:
 
 	std::shared_ptr<paimon::Predicate> predicates = nullptr;
 
+	vector<string> part_keys;
+	std::vector<std::map<std::string, std::string>> part_filters;
+	// Debug-only test hook: assert the planned split count before any
+	// reader-level or DuckDB-level filtering can affect the result.
+	std::optional<idx_t> debug_expected_splits;
+
 	string table_schema_json;
 };
 
@@ -397,6 +403,109 @@ static std::shared_ptr<paimon::Predicate> TryConvertExpression(const Expression 
 	}
 }
 
+static bool TryExtractPartitionFilter(const Expression &expr, LogicalGet &get, const unordered_set<string> &part_keys,
+                                      map<string, string> &part_filter) {
+	switch (expr.GetExpressionClass()) {
+	case ExpressionClass::BOUND_COMPARISON: {
+		auto &comp = expr.Cast<BoundComparisonExpression>();
+		if (comp.type != ExpressionType::COMPARE_EQUAL) {
+			break;
+		}
+
+		Expression *col_expr = nullptr;
+		Expression *const_expr = nullptr;
+
+		if (comp.left->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF &&
+		    comp.right->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+			col_expr = comp.left.get();
+			const_expr = comp.right.get();
+		} else if (comp.left->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT &&
+		           comp.right->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
+			col_expr = comp.right.get();
+			const_expr = comp.left.get();
+		} else {
+			break;
+		}
+
+		auto col_idx = get.GetColumnIds()[col_expr->Cast<BoundColumnRefExpression>().binding.column_index];
+		auto &col_name = get.GetColumnName(col_idx);
+
+		// Only extract filters on partition key columns.
+		if (part_keys.find(col_name) == part_keys.end()) {
+			break;
+		}
+
+		// NULL partition values cannot be used for partition pruning.
+		auto &val = const_expr->Cast<BoundConstantExpression>().value;
+		if (val.IsNull()) {
+			break;
+		}
+
+		part_filter[col_name] = val.ToString();
+		return true;
+	}
+	case ExpressionClass::BOUND_CONJUNCTION: {
+		auto &conj = expr.Cast<BoundConjunctionExpression>();
+		// OR is handled by the outer TryExtractPartitionFilters.
+		if (conj.type != ExpressionType::CONJUNCTION_AND) {
+			break;
+		}
+		bool matched = false;
+		for (auto &child : conj.children) {
+			// An AND branch may mix partition and non-partition predicates.
+			// Keep any partition constraints we can extract and leave the
+			// original expression for DuckDB to re-check.
+			if (TryExtractPartitionFilter(*child, get, part_keys, part_filter)) {
+				matched = true;
+			}
+		}
+		return matched;
+	}
+	default:
+		break;
+	}
+	return false;
+}
+
+static vector<map<string, string>> TryExtractPartitionFilters(const Expression &filter, LogicalGet &get,
+                                                              const unordered_set<string> &part_keys) {
+	switch (filter.GetExpressionClass()) {
+	// Single comparison: extract as one partition filter.
+	case ExpressionClass::BOUND_COMPARISON: {
+		map<string, string> part_filter;
+		if (TryExtractPartitionFilter(filter, get, part_keys, part_filter)) {
+			return {std::move(part_filter)};
+		}
+		break;
+	}
+	// AND: collect all conjuncts into one filter.
+	// OR: each disjunct becomes a separate filter; bail out if any fails.
+	case ExpressionClass::BOUND_CONJUNCTION: {
+		auto &conj = filter.Cast<BoundConjunctionExpression>();
+		if (conj.type == ExpressionType::CONJUNCTION_AND) {
+			map<string, string> part_filter;
+			if (TryExtractPartitionFilter(filter, get, part_keys, part_filter)) {
+				return {std::move(part_filter)};
+			}
+		} else if (conj.type == ExpressionType::CONJUNCTION_OR) {
+			vector<map<string, string>> filters;
+			for (auto &child : conj.children) {
+				map<string, string> part_filter;
+				if (!TryExtractPartitionFilter(*child, get, part_keys, part_filter)) {
+					return {};
+				}
+				filters.push_back(std::move(part_filter));
+			}
+			return filters;
+		}
+		break;
+	}
+	default:
+		break;
+	}
+	return {};
+}
+
 static void PaimonPushdownFilter(ClientContext &context, LogicalGet &get, FunctionData *bind_data,
                                  vector<unique_ptr<Expression>> &filters) {
 	auto &bind = bind_data->Cast<PaimonScanBindData>();
@@ -425,6 +534,70 @@ static void PaimonPushdownFilter(ClientContext &context, LogicalGet &get, Functi
 	} else {
 		bind.predicates = nullptr;
 	}
+	bind.part_filters.clear();
+
+	// Extract equality conditions on partition keys into a separate structure
+	// so that paimon-cpp can prune entire partitions during scan planning,
+	// before any data files are read.
+	//
+	// The top-level filters vector has AND semantics (DuckDB splits
+	// conjuncts into separate entries).  Each entry may yield one filter
+	// map (simple equality) or multiple maps (from OR).  We compute the
+	// cross-product across entries and merge maps within each combination,
+	// mirroring the manual And() applied for predicate pushdown above.
+	if (!bind.part_keys.empty()) {
+		unordered_set<string> part_keys(bind.part_keys.begin(), bind.part_keys.end());
+
+		vector<vector<map<string, string>>> per_expr;
+		for (idx_t i = 0; i < filters.size(); i++) {
+			auto part_filter = TryExtractPartitionFilters(*filters[i], get, part_keys);
+			// Filters unrelated to partition keys produce an empty vector
+			// and are excluded from the cross-product below.
+			if (!part_filter.empty()) {
+				per_expr.push_back(std::move(part_filter));
+			}
+		}
+
+		// Cross-product: per_expr entries have AND semantics (from
+		// DuckDB's top-level conjunct split), while maps within each
+		// entry have OR semantics.  Expanding AND-of-ORs into OR-of-ANDs
+		// (DNF) is a cartesian product that merges maps pairwise.
+		//
+		// If a pair assigns different values to the same partition key,
+		// that DNF branch is impossible and should be skipped; assigning
+		// the same value twice is fine.
+		if (!per_expr.empty()) {
+			auto merge_part_filter = [](const map<string, string> &existing, const map<string, string> &incoming,
+			                            map<string, string> &merged) {
+				merged = existing;
+				for (auto &entry : incoming) {
+					auto inserted = merged.insert(entry);
+					// insert() does not overwrite an existing key. If the key
+					// already exists with a different value, this AND branch is
+					// contradictory; the same value is just a duplicate filter.
+					if (!inserted.second && inserted.first->second != entry.second) {
+						return false;
+					}
+				}
+				return true;
+			};
+
+			vector<map<string, string>> combined = std::move(per_expr[0]);
+			for (idx_t i = 1; i < per_expr.size(); i++) {
+				vector<map<string, string>> next;
+				for (auto &existing : combined) {
+					for (auto &incoming : per_expr[i]) {
+						map<string, string> merged;
+						if (merge_part_filter(existing, incoming, merged)) {
+							next.push_back(std::move(merged));
+						}
+					}
+				}
+				combined = std::move(next);
+			}
+			bind.part_filters = std::move(combined);
+		}
+	}
 }
 
 static unique_ptr<FunctionData> PaimonScanBind(ClientContext &context, TableFunctionBindInput &input,
@@ -435,6 +608,14 @@ static unique_ptr<FunctionData> PaimonScanBind(ClientContext &context, TableFunc
 	bind_data->path = path;
 
 	unordered_map<string, Value> scan_options(input.named_parameters.begin(), input.named_parameters.end());
+	auto expected_splits = scan_options.find("debug_expected_splits");
+	if (expected_splits != scan_options.end()) {
+		auto expected_value = expected_splits->second.GetValue<int64_t>();
+		if (expected_value < 0) {
+			throw InvalidInputException("'debug_expected_splits' must be non-negative");
+		}
+		bind_data->debug_expected_splits = NumericCast<idx_t>(expected_value);
+	}
 	bind_data->paimon_options = PaimonCatalog::GetPaimonOptions(context, path.warehouse, scan_options);
 	auto paimon_catalog = PaimonCatalog::CreatePaimonCatalog(context, path.warehouse, scan_options);
 
@@ -443,6 +624,12 @@ static unique_ptr<FunctionData> PaimonScanBind(ClientContext &context, TableFunc
 		throw IOException(table_schema_result.status().ToString());
 	}
 	auto table_schema = std::move(table_schema_result).value();
+
+	auto data_schema = std::dynamic_pointer_cast<paimon::DataSchema>(table_schema);
+	if (data_schema) {
+		auto &part_keys = data_schema->PartitionKeys();
+		bind_data->part_keys.assign(part_keys.begin(), part_keys.end());
+	}
 
 	auto json_schema_result = table_schema->GetJsonSchema();
 	if (!json_schema_result.ok()) {
@@ -624,8 +811,11 @@ static unique_ptr<GlobalTableFunctionState> PaimonScanInitGlobal(ClientContext &
 	// construct the scanner
 	paimon::ScanContextBuilder scan_context_builder(path);
 
-	auto scan_context_result =
-	    scan_context_builder.SetOptions(bind.paimon_options).SetPredicate(bind.predicates).Finish();
+	scan_context_builder.SetOptions(bind.paimon_options).SetPredicate(bind.predicates);
+	if (!bind.part_filters.empty()) {
+		scan_context_builder.SetPartitionFilter(bind.part_filters);
+	}
+	auto scan_context_result = scan_context_builder.Finish();
 	if (!scan_context_result.ok()) {
 		throw IOException(scan_context_result.status().ToString());
 	}
@@ -644,6 +834,11 @@ static unique_ptr<GlobalTableFunctionState> PaimonScanInitGlobal(ClientContext &
 	auto plan = std::move(plan_result).value();
 
 	state->splits = plan->Splits();
+	if (bind.debug_expected_splits.has_value() && state->splits.size() != bind.debug_expected_splits.value()) {
+		throw InvalidInputException("Paimon scan planned %llu split(s), expected %llu",
+		                            NumericCast<unsigned long long>(state->splits.size()),
+		                            NumericCast<unsigned long long>(bind.debug_expected_splits.value()));
+	}
 	state->path = path;
 	state->arrow_table = bind.arrow_table;
 
@@ -710,6 +905,8 @@ TableFunctionSet PaimonFunctions::GetPaimonScanFunction() {
 	fun.named_parameters["file_format"] = LogicalType::VARCHAR;     // deprecated: auto-detected from table schema
 	fun.named_parameters["snapshot_from_id"] = LogicalType::BIGINT;
 	fun.named_parameters["snapshot_from_timestamp"] = LogicalType::TIMESTAMP;
+	// Debug-only test hook, not part of the public paimon_scan API.
+	fun.named_parameters["debug_expected_splits"] = LogicalType::BIGINT;
 	fun.init_local = PaimonScanInitLocal;
 	fun.projection_pushdown = true;
 	fun.pushdown_complex_filter = PaimonPushdownFilter;
@@ -720,6 +917,8 @@ TableFunctionSet PaimonFunctions::GetPaimonScanFunction() {
 	fun_fullpath.named_parameters["file_format"] = LogicalType::VARCHAR;     // deprecated
 	fun_fullpath.named_parameters["snapshot_from_id"] = LogicalType::BIGINT;
 	fun_fullpath.named_parameters["snapshot_from_timestamp"] = LogicalType::TIMESTAMP;
+	// Debug-only test hook, not part of the public paimon_scan API.
+	fun_fullpath.named_parameters["debug_expected_splits"] = LogicalType::BIGINT;
 	fun_fullpath.init_local = PaimonScanInitLocal;
 	fun_fullpath.projection_pushdown = true;
 	fun_fullpath.pushdown_complex_filter = PaimonPushdownFilter;

--- a/test/sql/partition_filter_pushdown.test
+++ b/test/sql/partition_filter_pushdown.test
@@ -1,0 +1,13 @@
+# name: test/sql/partition_filter_pushdown.test
+# group: [sql]
+
+require paimon
+
+statement ok
+ATTACH './data' AS pm (TYPE paimon);
+
+# DuckDB 1.4 does not parse CREATE TABLE ... PARTITIONED BY (...), so the
+# partitioned-table coverage for this feature lives on the DuckDB 1.5 branch.
+
+statement ok
+DETACH pm;

--- a/test/sql/predicate_pushdown.test
+++ b/test/sql/predicate_pushdown.test
@@ -3,6 +3,12 @@
 
 require paimon
 
+# predicate pushdown: full table scan plans one split
+query I
+SELECT count(*) FROM paimon_scan('./data/testdb.db/testtbl', debug_expected_splits=1);
+----
+9
+
 # predicate pushdown: equality
 query II
 SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 = 1;
@@ -13,7 +19,7 @@ Cathy	1
 
 # predicate pushdown: equality with no match
 query II
-SELECT f0, f3 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f3 = 16.0;
+SELECT f0, f3 FROM paimon_scan('./data/testdb.db/testtbl', debug_expected_splits=0) WHERE f3 = 16.0;
 ----
 
 # predicate pushdown: AND with unconvertible child (partial pushdown)
@@ -79,7 +85,7 @@ Iris	3	2
 
 # predicate pushdown: nested AND inside OR with no match (filter impossible partitions)
 query III
-SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl') WHERE (f1 = 1 AND f2 = 3) OR (f1 = 3 AND f2 = 3);
+SELECT f0, f1, f2 FROM paimon_scan('./data/testdb.db/testtbl', debug_expected_splits=0) WHERE (f1 = 1 AND f2 = 3) OR (f1 = 3 AND f2 = 3);
 ----
 
 # predicate pushdown: IN
@@ -103,7 +109,7 @@ Grace	0
 
 # predicate pushdown: IN with no match
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 IN (4, 5);
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', debug_expected_splits=0) WHERE f1 IN (4, 5);
 ----
 
 # predicate pushdown: NOT IN
@@ -211,7 +217,7 @@ Iris	3
 
 # predicate pushdown: IS NULL (no nulls in test data, expect empty result)
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f0 IS NULL;
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', debug_expected_splits=0) WHERE f0 IS NULL;
 ----
 
 # predicate pushdown: IS NOT NULL (no nulls in test data, expect all rows)
@@ -230,7 +236,7 @@ Iris	3
 
 # predicate pushdown: IS NULL on integer column
 query II
-SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 IS NULL;
+SELECT f0, f1 FROM paimon_scan('./data/testdb.db/testtbl', debug_expected_splits=0) WHERE f1 IS NULL;
 ----
 
 # predicate pushdown: IS NOT NULL combined with AND


### PR DESCRIPTION
## Summary

- push partition filters into Paimon planning so scans can prune partitions before row evaluation
- support writes to partitioned tables by grouping rows by partition value and attaching partition metadata
- preserve SQL NULL row values while using Paimon default markers in partition metadata

## Testing

- GEN=ninja make debug
- make test_debug