### PR TITLE
ci: align Linux release bundle with DuckDB

### DIFF
--- a/.github/workflows/release-bundle.yml
+++ b/.github/workflows/release-bundle.yml
@@ -26,9 +26,11 @@ jobs:
       matrix:
         include:
           - bundle_arch: linux-amd64
-            runner: ubuntu-22.04
+            runner: ubuntu-24.04
+            manylinux_image: x86_64
           - bundle_arch: linux-arm64
-            runner: ubuntu-22.04-arm
+            runner: ubuntu-24.04-arm
+            manylinux_image: aarch64
           - bundle_arch: osx-arm64
             runner: macos-14
     steps:
@@ -55,7 +57,34 @@ jobs:
           git -C duckdb fetch --force --tags
           git -C duckdb describe --tags --long
 
-      - name: Build extension (release)
+      - name: Build extension (release, Linux)
+        if: startsWith(matrix.bundle_arch, 'linux-')
+        shell: bash
+        run: |
+          set -euo pipefail
+          WORKSPACE="$(pwd)"
+          docker run --rm \
+            -v "${WORKSPACE}:${WORKSPACE}" \
+            -e GEN=ninja \
+            -e CC=gcc \
+            -e CXX=g++ \
+            quay.io/pypa/manylinux_2_28_${{ matrix.manylinux_image }} \
+            bash -c "
+              set -euo pipefail
+              umask 022
+              cat /etc/os-release
+              dnf install -y \
+                ninja-build \
+                perl-IPC-Cmd
+              git config --global --add safe.directory \"${WORKSPACE}\"
+              git config --global --add safe.directory \"${WORKSPACE}/duckdb\"
+              git config --global --add safe.directory \"${WORKSPACE}/extension-ci-tools\"
+              git config --global --add safe.directory \"${WORKSPACE}/third_party/paimon-cpp\"
+              make -C \"${WORKSPACE}\"
+            "
+
+      - name: Build extension (release, non-Linux)
+        if: ${{ !startsWith(matrix.bundle_arch, 'linux-') }}
         shell: bash
         run: |
           if command -v ninja &>/dev/null; then


### PR DESCRIPTION
## Summary

Build Linux release bundles inside the DuckDB manylinux 2.28 baseline instead of the native GitHub runner environment. Use plain gcc/g++ in the container so paimon-cpp ExternalProject builds do not misinterpret ccache as the compiler.

Configure Git safe.directory broadly inside the release container so DuckDB and nested submodules can resolve their version metadata instead of falling back to v0.0.1.

## Validation

- Release bundle workflow succeeded for v0.0.7-variegata in the fork.
- Linux amd64 and arm64 release archives were inspected locally.
- Highest observed GLIBCXX requirement was GLIBCXX_3.4.11, with no GLIBCXX_3.4.29 requirement.