### PR TITLE
feat(scan): optimize unfiltered Paimon count

### DIFF
--- a/patches/paimon-cpp-macos-ndebug-for-checked-cast.patch
+++ b/patches/paimon-cpp-macos-ndebug-for-checked-cast.patch
@@ -1,5 +1,5 @@
 diff --git a/cmake_modules/BuildUtils.cmake b/cmake_modules/BuildUtils.cmake
-index ed27ed7..1a4e79c 100644
+index 30647af..48bd44d 100644
 --- a/cmake_modules/BuildUtils.cmake
 +++ b/cmake_modules/BuildUtils.cmake
 @@ -176,7 +176,13 @@ function(add_paimon_lib LIB_NAME)
@@ -14,6 +14,6 @@ index ed27ed7..1a4e79c 100644
 +            # falls back to static_cast (same as Release mode).
 +            target_compile_definitions(${LIB_NAME}_objlib PRIVATE $<$<CONFIG:Debug>:NDEBUG>)
 +        else()
-             target_link_options(${LIB_NAME}_shared
-                                 PRIVATE
-                                 -Wl,--exclude-libs,ALL
+             set(SHARED_LINK_OPTIONS -Wl,--exclude-libs,ALL -Wl,-Bsymbolic
+                                     -Wl,--gc-sections)
+             # -z defs (--no-undefined) rejects the __asan_*/__ubsan_* symbols that

--- a/src/paimon_storage/paimon_scan.cpp
+++ b/src/paimon_storage/paimon_scan.cpp
@@ -24,6 +24,7 @@
 
 #include "duckdb.hpp"
 #include "duckdb/common/constants.hpp"
+#include "duckdb/function/partition_stats.hpp"
 #include "duckdb/function/table/arrow.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
@@ -51,6 +52,7 @@ namespace duckdb {
 struct PaimonScanBindData : public TableFunctionData {
 public:
 	PaimonTablePath path;
+	string table_data_path;
 
 	map<string, string> paimon_options;
 
@@ -609,6 +611,7 @@ static unique_ptr<FunctionData> PaimonScanBind(ClientContext &context, TableFunc
 
 	auto path = PaimonTablePath::Parse(input.inputs);
 	bind_data->path = path;
+	bind_data->table_data_path = path.warehouse + "/" + path.dbname + paimon::Catalog::DB_SUFFIX + "/" + path.tablename;
 
 	unordered_map<string, Value> scan_options(input.named_parameters.begin(), input.named_parameters.end());
 	auto expected_splits = scan_options.find("debug_expected_splits");
@@ -673,6 +676,34 @@ struct PaimonScanGlobalState : public GlobalTableFunctionState {
 		return splits.size();
 	}
 };
+
+static std::vector<std::shared_ptr<paimon::Split>> CreatePaimonScanSplits(const PaimonScanBindData &bind) {
+	paimon::ScanContextBuilder scan_context_builder(bind.table_data_path);
+	scan_context_builder.SetOptions(bind.paimon_options).SetPredicate(bind.predicates);
+	if (!bind.part_filters.empty()) {
+		scan_context_builder.SetPartitionFilter(bind.part_filters);
+	}
+
+	auto scan_context_result = scan_context_builder.Finish();
+	if (!scan_context_result.ok()) {
+		throw IOException(scan_context_result.status().ToString());
+	}
+	auto scan_context = std::move(scan_context_result).value();
+
+	auto scanner_result = paimon::TableScan::Create(std::move(scan_context));
+	if (!scanner_result.ok()) {
+		throw IOException(scanner_result.status().ToString());
+	}
+	auto scanner = std::move(scanner_result).value();
+
+	auto plan_result = scanner->CreatePlan();
+	if (!plan_result.ok()) {
+		throw IOException(plan_result.status().ToString());
+	}
+	auto plan = std::move(plan_result).value();
+
+	return plan->Splits();
+}
 
 struct PaimonScanLocalState : public LocalTableFunctionState {
 public:
@@ -807,43 +838,70 @@ static unique_ptr<GlobalTableFunctionState> PaimonScanInitGlobal(ClientContext &
 		state->paimon_predicates = pred_res.value();
 	}
 
-	auto path = bind.path.warehouse + "/" + bind.path.dbname + paimon::Catalog::DB_SUFFIX + "/" + bind.path.tablename;
-
-	// construct the scanner
-	paimon::ScanContextBuilder scan_context_builder(path);
-
-	scan_context_builder.SetOptions(bind.paimon_options).SetPredicate(bind.predicates);
-	if (!bind.part_filters.empty()) {
-		scan_context_builder.SetPartitionFilter(bind.part_filters);
-	}
-	auto scan_context_result = scan_context_builder.Finish();
-	if (!scan_context_result.ok()) {
-		throw IOException(scan_context_result.status().ToString());
-	}
-	auto scan_context = std::move(scan_context_result).value();
-
-	auto scanner_result = paimon::TableScan::Create(std::move(scan_context));
-	if (!scanner_result.ok()) {
-		throw IOException(scanner_result.status().ToString());
-	}
-	auto scanner = std::move(scanner_result).value();
-
-	auto plan_result = scanner->CreatePlan();
-	if (!plan_result.ok()) {
-		throw IOException(plan_result.status().ToString());
-	}
-	auto plan = std::move(plan_result).value();
-
-	state->splits = plan->Splits();
+	state->splits = CreatePaimonScanSplits(bind);
 	if (bind.debug_expected_splits.has_value() && state->splits.size() != bind.debug_expected_splits.value()) {
 		throw InvalidInputException("Paimon scan planned %llu split(s), expected %llu",
 		                            NumericCast<unsigned long long>(state->splits.size()),
 		                            NumericCast<unsigned long long>(bind.debug_expected_splits.value()));
 	}
-	state->path = path;
+	state->path = bind.table_data_path;
 	state->arrow_table = bind.arrow_table;
 
 	return std::move(state);
+}
+
+static vector<PartitionStatistics> PaimonGetPartitionStats(ClientContext &, GetPartitionStatsInput &input) {
+	vector<PartitionStatistics> result;
+	auto &bind = input.bind_data->Cast<PaimonScanBindData>();
+
+	// The current filter pushdown path keeps DuckDB residual filters for correctness.
+	// Only expose exact counts for unfiltered scans, where DuckDB can safely replace
+	// COUNT(*) with a constant.
+	if (bind.predicates != nullptr || !bind.part_filters.empty()) {
+		return result;
+	}
+
+	std::vector<std::shared_ptr<paimon::Split>> splits;
+	try {
+		splits = CreatePaimonScanSplits(bind);
+	} catch (...) {
+		return result;
+	}
+
+	paimon::ReadContextBuilder read_context_builder(bind.table_data_path);
+	auto read_context_result =
+	    read_context_builder.SetOptions(bind.paimon_options).SetTableSchema(bind.table_schema_json).Finish();
+	if (!read_context_result.ok()) {
+		return result;
+	}
+	auto read_context = std::move(read_context_result).value();
+
+	auto table_read_result = paimon::TableRead::Create(std::move(read_context));
+	if (!table_read_result.ok()) {
+		return result;
+	}
+	auto table_read = std::move(table_read_result).value();
+
+	auto count_reader_result = table_read->CreateCountReader(splits);
+	if (!count_reader_result.ok()) {
+		return result;
+	}
+	auto count_reader = std::move(count_reader_result).value();
+
+	auto count_result = count_reader->CountRows();
+	if (!count_result.ok()) {
+		return result;
+	}
+	auto row_count = std::move(count_result).value();
+	if (row_count < 0) {
+		return result;
+	}
+
+	PartitionStatistics stats;
+	stats.count = NumericCast<idx_t>(row_count);
+	stats.count_type = CountType::COUNT_EXACT;
+	result.push_back(std::move(stats));
+	return result;
 }
 
 static unique_ptr<LocalTableFunctionState> PaimonScanInitLocal(ExecutionContext &context, TableFunctionInitInput &input,
@@ -911,6 +969,7 @@ TableFunctionSet PaimonFunctions::GetPaimonScanFunction() {
 	fun.init_local = PaimonScanInitLocal;
 	fun.projection_pushdown = true;
 	fun.pushdown_complex_filter = PaimonPushdownFilter;
+	fun.get_partition_stats = PaimonGetPartitionStats;
 	function_set.AddFunction(fun);
 
 	auto fun_fullpath = TableFunction({LogicalType::VARCHAR}, PaimonScan, PaimonScanBind, PaimonScanInitGlobal);
@@ -923,6 +982,7 @@ TableFunctionSet PaimonFunctions::GetPaimonScanFunction() {
 	fun_fullpath.init_local = PaimonScanInitLocal;
 	fun_fullpath.projection_pushdown = true;
 	fun_fullpath.pushdown_complex_filter = PaimonPushdownFilter;
+	fun_fullpath.get_partition_stats = PaimonGetPartitionStats;
 	function_set.AddFunction(fun_fullpath);
 
 	return function_set;

--- a/test/sql/paimon_count_stats.test
+++ b/test/sql/paimon_count_stats.test
@@ -1,0 +1,93 @@
+# name: test/sql/paimon_count_stats.test
+# group: [sql]
+
+require paimon
+
+require no_alternative_verify
+
+statement ok
+ATTACH './data' AS pm (TYPE paimon);
+
+statement ok
+DROP TABLE IF EXISTS pm.__test_count_stats.t1;
+
+statement ok
+DROP SCHEMA IF EXISTS pm.__test_count_stats CASCADE;
+
+statement ok
+CREATE SCHEMA pm.__test_count_stats;
+
+statement ok
+CREATE TABLE pm.__test_count_stats.t1 (
+    id INTEGER,
+    dt VARCHAR
+) PARTITIONED BY (dt);
+
+statement ok
+INSERT INTO pm.__test_count_stats.t1
+    SELECT
+        i AS id,
+        CASE i % 2
+            WHEN 0 THEN '2024-02-01'
+            ELSE '2024-02-02'
+        END AS dt
+    FROM generate_series(1, 12) t(i);
+
+query II
+EXPLAIN SELECT count(*) FROM paimon_scan('./data/testdb.db/testtbl');
+----
+physical_plan	<REGEX>:.*COLUMN_DATA_SCAN.*
+
+query I
+SELECT count(*) FROM paimon_scan('./data/testdb.db/testtbl');
+----
+9
+
+query II
+EXPLAIN SELECT count(*) FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 = 1;
+----
+physical_plan	<REGEX>:.*PAIMON_SCAN.*
+
+query I
+SELECT count(*) FROM paimon_scan('./data/testdb.db/testtbl') WHERE f1 = 1;
+----
+3
+
+query II
+EXPLAIN SELECT count(*) FROM paimon_scan('./data/testdb.db/testtbl') WHERE cast(f1 AS VARCHAR) = '1';
+----
+physical_plan	<REGEX>:.*PAIMON_SCAN.*
+
+query I
+SELECT count(*) FROM paimon_scan('./data/testdb.db/testtbl') WHERE cast(f1 AS VARCHAR) = '1';
+----
+3
+
+query II
+EXPLAIN SELECT count(*) FROM paimon_scan('./data/__test_count_stats.db/t1');
+----
+physical_plan	<REGEX>:.*COLUMN_DATA_SCAN.*
+
+query I
+SELECT count(*) FROM paimon_scan('./data/__test_count_stats.db/t1');
+----
+12
+
+query II
+EXPLAIN SELECT count(*) FROM paimon_scan('./data/__test_count_stats.db/t1') WHERE dt = '2024-02-01';
+----
+physical_plan	<REGEX>:.*PAIMON_SCAN.*
+
+query I
+SELECT count(*) FROM paimon_scan('./data/__test_count_stats.db/t1') WHERE dt = '2024-02-01';
+----
+6
+
+statement ok
+DROP TABLE pm.__test_count_stats.t1;
+
+statement ok
+DROP SCHEMA pm.__test_count_stats;
+
+statement ok
+DETACH pm;


### PR DESCRIPTION
Optimize count(*) on Paimon scans when no filters are present. The scan now exposes exact row counts from Paimon so DuckDB can answer the aggregate during planning instead of scheduling a row-producing scan.\n\nFiltered counts continue to use the normal scan path because residual predicates are still evaluated by DuckDB for correctness.