### PR TITLE
refactor: resolve Paimon table locations through catalog

### DIFF
--- a/src/include/paimon_insert.hpp
+++ b/src/include/paimon_insert.hpp
@@ -26,6 +26,7 @@
 
 #include "duckdb/execution/physical_operator.hpp"
 #include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
+#include "paimon/catalog/identifier.h"
 
 #include <map>
 #include <string>
@@ -39,12 +40,12 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::EXTENSION;
 
 	PhysicalPaimonInsert(PhysicalPlan &physical_plan, LogicalOperator &op, SchemaCatalogEntry &schema,
-	                     unique_ptr<BoundCreateTableInfo> info, string table_path, map<string, string> paimon_options,
-	                     vector<string> part_keys, idx_t estimated_cardinality);
+	                     unique_ptr<BoundCreateTableInfo> info, paimon::Identifier table_identifier,
+	                     map<string, string> paimon_options, vector<string> part_keys, idx_t estimated_cardinality);
 
 	SchemaCatalogEntry *schema;
 	unique_ptr<BoundCreateTableInfo> info;
-	string table_path;
+	paimon::Identifier table_identifier;
 	map<string, string> paimon_options;
 	vector<string> part_keys;
 

--- a/src/paimon_storage/paimon_catalog.cpp
+++ b/src/paimon_storage/paimon_catalog.cpp
@@ -235,7 +235,7 @@ PhysicalOperator &PaimonCatalog::PlanCreateTableAs(ClientContext &context, Physi
 	}
 
 	auto &base = op.info->Base();
-	auto table_path = path + "/" + base.schema + paimon::Catalog::DB_SUFFIX + "/" + base.table;
+	paimon::Identifier table_identifier(base.schema, base.table);
 	auto paimon_options = GetPaimonOptions(context, path, attached_options);
 
 	vector<string> part_keys;
@@ -246,7 +246,7 @@ PhysicalOperator &PaimonCatalog::PlanCreateTableAs(ClientContext &context, Physi
 		part_keys.push_back(part_expr->Cast<ColumnRefExpression>().GetColumnName());
 	}
 
-	auto &insert = planner.Make<PhysicalPaimonInsert>(op, op.schema, std::move(op.info), std::move(table_path),
+	auto &insert = planner.Make<PhysicalPaimonInsert>(op, op.schema, std::move(op.info), std::move(table_identifier),
 	                                                  std::move(paimon_options), std::move(part_keys), 0U);
 	insert.children.push_back(plan);
 	return insert;
@@ -259,11 +259,11 @@ PhysicalOperator &PaimonCatalog::PlanInsert(ClientContext &context, PhysicalPlan
 	}
 
 	auto &table = op.table;
-	auto table_path = path + "/" + table.schema.name + paimon::Catalog::DB_SUFFIX + "/" + table.name;
+	paimon::Identifier table_identifier(table.schema.name, table.name);
 	auto paimon_options = GetPaimonOptions(context, path, attached_options);
 
 	vector<string> part_keys;
-	auto schema_result = paimon_catalog->LoadTableSchema(paimon::Identifier(table.schema.name, table.name));
+	auto schema_result = paimon_catalog->LoadTableSchema(table_identifier);
 	if (!schema_result.ok()) {
 		throw IOException(schema_result.status().ToString());
 	}
@@ -277,7 +277,7 @@ PhysicalOperator &PaimonCatalog::PlanInsert(ClientContext &context, PhysicalPlan
 		plan = planner.ResolveDefaultsProjection(op, *plan);
 	}
 
-	auto &insert = planner.Make<PhysicalPaimonInsert>(op, table.schema, nullptr, std::move(table_path),
+	auto &insert = planner.Make<PhysicalPaimonInsert>(op, table.schema, nullptr, std::move(table_identifier),
 	                                                  std::move(paimon_options), std::move(part_keys), 0U);
 	if (plan) {
 		insert.children.push_back(*plan);

--- a/src/paimon_storage/paimon_insert.cpp
+++ b/src/paimon_storage/paimon_insert.cpp
@@ -45,11 +45,11 @@
 namespace duckdb {
 
 PhysicalPaimonInsert::PhysicalPaimonInsert(PhysicalPlan &physical_plan, LogicalOperator &op, SchemaCatalogEntry &schema,
-                                           unique_ptr<BoundCreateTableInfo> info, string table_path,
+                                           unique_ptr<BoundCreateTableInfo> info, paimon::Identifier table_identifier,
                                            map<string, string> paimon_options, vector<string> part_keys,
                                            idx_t estimated_cardinality)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, {LogicalType::BIGINT}, estimated_cardinality),
-      schema(&schema), info(std::move(info)), table_path(std::move(table_path)),
+      schema(&schema), info(std::move(info)), table_identifier(std::move(table_identifier)),
       paimon_options(std::move(paimon_options)), part_keys(std::move(part_keys)) {
 }
 
@@ -61,6 +61,7 @@ struct PaimonInsertGlobalState : public GlobalSinkState {
 	std::mutex lock;
 	std::atomic<int32_t> next_write_id {0};
 	std::vector<std::shared_ptr<paimon::CommitMessage>> all_commit_messages;
+	string table_path;
 	idx_t insert_count = 0;
 	bool finished = false;
 
@@ -87,18 +88,16 @@ unique_ptr<GlobalSinkState> PhysicalPaimonInsert::GetGlobalSinkState(ClientConte
 		paimon_schema.CreateTable(txn, *info);
 	}
 
+	auto &paimon_catalog = schema->catalog.Cast<PaimonCatalog>();
+	auto &catalog = paimon_catalog.GetPaimonCatalog();
+	auto table_path_result = catalog.GetTableLocation(table_identifier);
+	if (!table_path_result.ok()) {
+		throw IOException(table_path_result.status().ToString());
+	}
+	state->table_path = std::move(table_path_result).value();
+
 	if (!part_keys.empty()) {
-		auto &paimon_catalog = schema->catalog.Cast<PaimonCatalog>();
-		auto &catalog = paimon_catalog.GetPaimonCatalog();
-		auto schema_name = info ? info->Base().schema : schema->name;
-		auto table_name = info ? info->Base().table : string();
-
-		if (table_name.empty()) {
-			auto last_slash = table_path.rfind('/');
-			table_name = (last_slash != string::npos) ? table_path.substr(last_slash + 1) : table_path;
-		}
-
-		auto schema_result = catalog.LoadTableSchema(paimon::Identifier(schema_name, table_name));
+		auto schema_result = catalog.LoadTableSchema(table_identifier);
 		if (!schema_result.ok()) {
 			throw IOException(schema_result.status().ToString());
 		}
@@ -135,7 +134,7 @@ unique_ptr<LocalSinkState> PhysicalPaimonInsert::GetLocalSinkState(ExecutionCont
 
 	int32_t write_id = gstate.next_write_id.fetch_add(1);
 
-	paimon::WriteContextBuilder write_builder(table_path, "duckdb");
+	paimon::WriteContextBuilder write_builder(gstate.table_path, "duckdb");
 	auto write_ctx_result = write_builder.WithWriteId(write_id).SetOptions(paimon_options).Finish();
 	if (!write_ctx_result.ok()) {
 		throw IOException(write_ctx_result.status().ToString());
@@ -274,7 +273,7 @@ SinkFinalizeType PhysicalPaimonInsert::Finalize(Pipeline &pipeline, Event &event
 		return SinkFinalizeType::READY;
 	}
 
-	paimon::CommitContextBuilder commit_builder(table_path, "duckdb");
+	paimon::CommitContextBuilder commit_builder(gstate.table_path, "duckdb");
 	auto commit_ctx_result = commit_builder.SetOptions(paimon_options).Finish();
 	if (!commit_ctx_result.ok()) {
 		throw IOException(commit_ctx_result.status().ToString());

--- a/src/paimon_storage/paimon_scan.cpp
+++ b/src/paimon_storage/paimon_scan.cpp
@@ -611,7 +611,6 @@ static unique_ptr<FunctionData> PaimonScanBind(ClientContext &context, TableFunc
 
 	auto path = PaimonTablePath::Parse(input.inputs);
 	bind_data->path = path;
-	bind_data->table_data_path = path.warehouse + "/" + path.dbname + paimon::Catalog::DB_SUFFIX + "/" + path.tablename;
 
 	unordered_map<string, Value> scan_options(input.named_parameters.begin(), input.named_parameters.end());
 	auto expected_splits = scan_options.find("debug_expected_splits");
@@ -624,8 +623,14 @@ static unique_ptr<FunctionData> PaimonScanBind(ClientContext &context, TableFunc
 	}
 	bind_data->paimon_options = PaimonCatalog::GetPaimonOptions(context, path.warehouse, scan_options);
 	auto paimon_catalog = PaimonCatalog::CreatePaimonCatalog(context, path.warehouse, scan_options);
+	paimon::Identifier table_identifier(path.dbname, path.tablename);
+	auto table_path_result = paimon_catalog->GetTableLocation(table_identifier);
+	if (!table_path_result.ok()) {
+		throw IOException(table_path_result.status().ToString());
+	}
+	bind_data->table_data_path = std::move(table_path_result).value();
 
-	auto table_schema_result = paimon_catalog->LoadTableSchema(paimon::Identifier(path.dbname, path.tablename));
+	auto table_schema_result = paimon_catalog->LoadTableSchema(table_identifier);
 	if (!table_schema_result.ok()) {
 		throw IOException(table_schema_result.status().ToString());
 	}


### PR DESCRIPTION
Resolve physical Paimon table locations through the catalog instead of constructing them from the warehouse path.

This lets catalog implementations, including REST-backed catalogs, control the actual table location used for scans and writes.

Validated with `GEN=ninja make debug` and `make test_debug` (983 assertions).