### PR TITLE
feat: add OSS v2 filesystem support

### DIFF
--- a/.github/workflows/release-bundle.yml
+++ b/.github/workflows/release-bundle.yml
@@ -115,7 +115,6 @@ jobs:
             osx-*)   LIB_EXT="dylib" ;;
           esac
           cp "${EXT_DIR}"/libpaimon*."${LIB_EXT}"* "${STAGE_DIR}/"
-          cp "${EXT_DIR}"/libjindosdk_c*."${LIB_EXT}"* "${STAGE_DIR}/"
 
           cp LICENSE "${STAGE_DIR}/LICENSE"
           cp README.md "${STAGE_DIR}/README.md"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ ExternalProject_Add(paimon_cpp_ep
     -DPAIMON_BUILD_SHARED=ON
     -DPAIMON_BUILD_STATIC=OFF
     -DPAIMON_ENABLE_JINDO=ON
+    -DPAIMON_ENABLE_OSS=ON
     -DPAIMON_ENABLE_S3=ON
     -DPAIMON_ENABLE_REST=ON
     -DPAIMON_ENABLE_ORC=ON
@@ -88,6 +89,7 @@ ExternalProject_Add(paimon_cpp_ep
     ${PAIMON_CPP_LIB}/libpaimon_global_index${CMAKE_SHARED_LIBRARY_SUFFIX}
     ${PAIMON_CPP_LIB}/libpaimon_local_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
     ${PAIMON_CPP_LIB}/libpaimon_jindo_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
+    ${PAIMON_CPP_LIB}/libpaimon_oss_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
     ${PAIMON_CPP_LIB}/libpaimon_s3_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
     ${PAIMON_CPP_LIB}/${JINDOSDK_C_INSTALLED_NAME}
     ${PAIMON_CPP_LIB}/libpaimon_parquet_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}
@@ -143,6 +145,7 @@ set(PAIMON_CPP_LIBS
   ${PAIMON_CPP_LIB}/libpaimon_global_index${CMAKE_SHARED_LIBRARY_SUFFIX}
   ${PAIMON_CPP_LIB}/libpaimon_local_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
   ${PAIMON_CPP_LIB}/libpaimon_jindo_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
+  ${PAIMON_CPP_LIB}/libpaimon_oss_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
   ${PAIMON_CPP_LIB}/libpaimon_s3_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
   ${PAIMON_CPP_LIB}/${JINDOSDK_C_INSTALLED_NAME}
   ${PAIMON_CPP_LIB}/libpaimon_parquet_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}
@@ -170,6 +173,7 @@ set(PAIMON_CPP_RUNTIME_BUNDLE_LIBS
   ${PAIMON_CPP_LIB}/libpaimon_global_index${CMAKE_SHARED_LIBRARY_SUFFIX}
   ${PAIMON_CPP_LIB}/libpaimon_local_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
   ${PAIMON_CPP_LIB}/libpaimon_jindo_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
+  ${PAIMON_CPP_LIB}/libpaimon_oss_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
   ${PAIMON_CPP_LIB}/libpaimon_s3_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
   ${PAIMON_CPP_LIB}/${JINDOSDK_C_RUNTIME_NAME}
   ${PAIMON_CPP_LIB}/libpaimon_parquet_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,20 +15,6 @@ include_directories(src/include)
 # Import paimon-cpp as a subproject
 include(ExternalProject)
 
-# JindoSDK: the installed filename differs by platform, but we always bundle
-# using the short name that matches the dylib's install_name.
-file(STRINGS third_party/paimon-cpp/third_party/versions.txt
-     _jindosdk_ver REGEX "^PAIMON_JINDOSDK_C_BUILD_VERSION=")
-string(REGEX REPLACE ".*=" "" _jindosdk_ver "${_jindosdk_ver}")
-string(REGEX REPLACE "([0-9]+)\\..*" "\\1" _jindosdk_major "${_jindosdk_ver}")
-if(APPLE)
-  set(JINDOSDK_C_INSTALLED_NAME "libjindosdk_c.${_jindosdk_ver}.dylib")
-  set(JINDOSDK_C_RUNTIME_NAME "libjindosdk_c.${_jindosdk_major}.dylib")
-else()
-  set(JINDOSDK_C_INSTALLED_NAME "libjindosdk_c.so")
-  set(JINDOSDK_C_RUNTIME_NAME "libjindosdk_c.so.${_jindosdk_major}")
-endif()
-
 set(PAIMON_CPP_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/paimon-cpp)
 set(PAIMON_CPP_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/paimon-cpp-install)
 set(PAIMON_CPP_INCLUDE ${PAIMON_CPP_PREFIX}/include)
@@ -74,7 +60,7 @@ ExternalProject_Add(paimon_cpp_ep
     -DPAIMON_BUILD_TESTS=OFF
     -DPAIMON_BUILD_SHARED=ON
     -DPAIMON_BUILD_STATIC=OFF
-    -DPAIMON_ENABLE_JINDO=ON
+    -DPAIMON_ENABLE_JINDO=OFF
     -DPAIMON_ENABLE_OSS=ON
     -DPAIMON_ENABLE_S3=ON
     -DPAIMON_ENABLE_REST=ON
@@ -88,28 +74,13 @@ ExternalProject_Add(paimon_cpp_ep
     ${PAIMON_CPP_LIB}/libpaimon_file_index${CMAKE_SHARED_LIBRARY_SUFFIX}
     ${PAIMON_CPP_LIB}/libpaimon_global_index${CMAKE_SHARED_LIBRARY_SUFFIX}
     ${PAIMON_CPP_LIB}/libpaimon_local_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
-    ${PAIMON_CPP_LIB}/libpaimon_jindo_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
     ${PAIMON_CPP_LIB}/libpaimon_oss_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
     ${PAIMON_CPP_LIB}/libpaimon_s3_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
-    ${PAIMON_CPP_LIB}/${JINDOSDK_C_INSTALLED_NAME}
     ${PAIMON_CPP_LIB}/libpaimon_parquet_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}
     ${PAIMON_CPP_LIB}/libpaimon_orc_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}
     ${PAIMON_CPP_LIB}/libpaimon_avro_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}
     ${PAIMON_CPP_LIB}/libpaimon_blob_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}
 )
-
-# On macOS, paimon-cpp installs the JindoSDK dylib with a versioned filename
-# (e.g. libjindosdk_c.6.10.2.dylib) but its install_name uses the short
-# version (libjindosdk_c.6.dylib). Add a post-install step to provide the
-# short-named copy that runtime lookup expects.
-if(APPLE)
-  ExternalProject_Add_Step(paimon_cpp_ep jindosdk_short_name
-    DEPENDEES install
-    BYPRODUCTS ${PAIMON_CPP_LIB}/${JINDOSDK_C_RUNTIME_NAME}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-      ${PAIMON_CPP_LIB}/${JINDOSDK_C_INSTALLED_NAME}
-      ${PAIMON_CPP_LIB}/${JINDOSDK_C_RUNTIME_NAME})
-endif()
 
 # Extension sources
 set(EXTENSION_SOURCES
@@ -144,10 +115,8 @@ set(PAIMON_CPP_LIBS
   ${PAIMON_CPP_LIB}/libpaimon_file_index${CMAKE_SHARED_LIBRARY_SUFFIX}
   ${PAIMON_CPP_LIB}/libpaimon_global_index${CMAKE_SHARED_LIBRARY_SUFFIX}
   ${PAIMON_CPP_LIB}/libpaimon_local_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
-  ${PAIMON_CPP_LIB}/libpaimon_jindo_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
   ${PAIMON_CPP_LIB}/libpaimon_oss_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
   ${PAIMON_CPP_LIB}/libpaimon_s3_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
-  ${PAIMON_CPP_LIB}/${JINDOSDK_C_INSTALLED_NAME}
   ${PAIMON_CPP_LIB}/libpaimon_parquet_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}
   ${PAIMON_CPP_LIB}/libpaimon_orc_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}
   ${PAIMON_CPP_LIB}/libpaimon_avro_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}
@@ -172,10 +141,8 @@ set(PAIMON_CPP_RUNTIME_BUNDLE_LIBS
   ${PAIMON_CPP_LIB}/libpaimon_file_index${CMAKE_SHARED_LIBRARY_SUFFIX}
   ${PAIMON_CPP_LIB}/libpaimon_global_index${CMAKE_SHARED_LIBRARY_SUFFIX}
   ${PAIMON_CPP_LIB}/libpaimon_local_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
-  ${PAIMON_CPP_LIB}/libpaimon_jindo_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
   ${PAIMON_CPP_LIB}/libpaimon_oss_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
   ${PAIMON_CPP_LIB}/libpaimon_s3_file_system${CMAKE_SHARED_LIBRARY_SUFFIX}
-  ${PAIMON_CPP_LIB}/${JINDOSDK_C_RUNTIME_NAME}
   ${PAIMON_CPP_LIB}/libpaimon_parquet_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}
   ${PAIMON_CPP_LIB}/libpaimon_orc_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}
   ${PAIMON_CPP_LIB}/libpaimon_avro_file_format${CMAKE_SHARED_LIBRARY_SUFFIX}

--- a/patches/paimon-cpp-install-arrow-headers.patch
+++ b/patches/paimon-cpp-install-arrow-headers.patch
@@ -1,15 +1,9 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -336,6 +336,11 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
-         DESTINATION "include"
-         FILES_MATCHING
-         PATTERN "*.h")
+@@ -363,0 +364,5 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
 +install(DIRECTORY ${ARROW_INCLUDE_DIR}/
 +        DESTINATION "include"
 +        FILES_MATCHING
 +        PATTERN "*.h"
 +        PATTERN "*.hpp")
-
- set(CMAKE_CXX_VISIBILITY_PRESET hidden)
- set(CMAKE_C_VISIBILITY_PRESET hidden)

--- a/src/paimon_extension.cpp
+++ b/src/paimon_extension.cpp
@@ -54,6 +54,7 @@ static unique_ptr<BaseSecret> CreatePaimonSecretFromConfig(ClientContext &contex
 	result->TrySetValue("region", input);
 	result->TrySetValue("profile", input);
 	result->TrySetValue("path_style_access", input);
+	result->TrySetValue("signature_version", input);
 
 	result->redact_keys = {"key_id", "secret", "session_token"};
 
@@ -75,6 +76,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	secret_fun.named_parameters["session_token"] = LogicalType::VARCHAR;
 	secret_fun.named_parameters["region"] = LogicalType::VARCHAR;
 	secret_fun.named_parameters["path_style_access"] = LogicalType::BOOLEAN;
+	secret_fun.named_parameters["signature_version"] = LogicalType::VARCHAR;
 	loader.RegisterFunction(secret_fun);
 
 	CreateSecretFunction credential_chain_fun = {"paimon", "credential_chain", CreatePaimonSecretFromConfig};

--- a/src/paimon_storage/paimon_catalog.cpp
+++ b/src/paimon_storage/paimon_catalog.cpp
@@ -155,7 +155,7 @@ map<string, string> PaimonCatalog::GetPaimonOptions(ClientContext &context, cons
 	const bool is_s3 = StringUtil::StartsWith(normalized_path, S3_PATH_PREFIX);
 
 	if (is_oss) {
-		paimon_options[paimon::Options::FILE_SYSTEM] = "jindo";
+		paimon_options[paimon::Options::FILE_SYSTEM] = "oss";
 	} else if (is_s3) {
 		paimon_options[paimon::Options::FILE_SYSTEM] = "s3";
 	} else {
@@ -176,19 +176,13 @@ map<string, string> PaimonCatalog::GetPaimonOptions(ClientContext &context, cons
 		}
 
 		if (is_oss) {
-			auto bucket_start = string(OSS_PATH_PREFIX).size();
-			auto bucket_end = path.find('/', bucket_start);
-			string bucket =
-			    path.substr(bucket_start, bucket_end == string::npos ? string::npos : bucket_end - bucket_start);
-			if (bucket.empty()) {
-				throw IOException("Invalid OSS path, cannot extract bucket name: " + path);
-			}
-
-			paimon_options["fs.oss.user"] = "paimon";
-			auto bucket_option_prefix = "fs.oss.bucket." + bucket + ".";
-			AddRequiredSecretOption(kv_secret, "key_id", bucket_option_prefix + "accessKeyId", paimon_options);
-			AddRequiredSecretOption(kv_secret, "secret", bucket_option_prefix + "accessKeySecret", paimon_options);
-			AddRequiredSecretOption(kv_secret, "endpoint", bucket_option_prefix + "endpoint", paimon_options);
+			AddRequiredSecretOption(kv_secret, "key_id", "fs.oss.accessKeyId", paimon_options);
+			AddRequiredSecretOption(kv_secret, "secret", "fs.oss.accessKeySecret", paimon_options);
+			AddOptionalSecretOption(kv_secret, "session_token", "fs.oss.sessionToken", paimon_options);
+			AddOptionalSecretOption(kv_secret, "region", "fs.oss.region", paimon_options);
+			AddOptionalSecretOption(kv_secret, "endpoint", "fs.oss.endpoint", paimon_options);
+			AddOptionalSecretOption(kv_secret, "path_style_access", "fs.oss.usePathStyle", paimon_options);
+			AddOptionalSecretOption(kv_secret, "signature_version", "fs.oss.signatureVersion", paimon_options);
 		} else if (is_s3) {
 			AddOptionalSecretOption(kv_secret, "key_id", "s3.access-key", paimon_options);
 			AddOptionalSecretOption(kv_secret, "secret", "s3.secret-key", paimon_options);

--- a/test/sql/paimon_oss_secret.test
+++ b/test/sql/paimon_oss_secret.test
@@ -1,0 +1,42 @@
+# name: test/sql/paimon_oss_secret.test
+# group: [sql]
+
+require paimon
+
+statement ok
+CREATE SECRET paimon_oss_root (
+    TYPE paimon,
+    key_id 'key-id',
+    secret 'secret-value',
+    endpoint 'oss-cn-hangzhou.aliyuncs.com',
+    signature_version 'v4',
+    scope 'oss://paimon-test'
+);
+
+statement ok
+CREATE SECRET paimon_oss_warehouse (
+    TYPE paimon,
+    key_id 'key-id',
+    secret 'secret-value',
+    session_token 'session-token',
+    region 'cn-hangzhou',
+    path_style_access false,
+    signature_version 'v1',
+    scope 'oss://paimon-test/warehouse'
+);
+
+query I
+SELECT name FROM which_secret('oss://paimon-test/warehouse/db.db/table', 'paimon');
+----
+paimon_oss_warehouse
+
+query I
+SELECT count(*)
+FROM duckdb_secrets()
+WHERE name = 'paimon_oss_warehouse'
+  AND secret_string LIKE '%key_id=redacted%'
+  AND secret_string LIKE '%secret=redacted%'
+  AND secret_string LIKE '%session_token=redacted%'
+  AND secret_string LIKE '%signature_version=v1%';
+----
+1


### PR DESCRIPTION
Backports native Alibaba Cloud OSS filesystem support through OSS SDK v2 to the DuckDB 1.4 branch.

This replaces the Jindo runtime dependency, wires OSS secrets into Paimon options, and bundles the OSS filesystem plugin with the extension.

Validated with a clean release build and a real OSS-backed Paimon table scan.