### PR TITLE
fix(build): guard disabled object store features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,14 @@ build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})
 target_include_directories(${EXTENSION_NAME} SYSTEM PRIVATE ${PAIMON_CPP_INCLUDE})
 target_include_directories(${TARGET_NAME}_loadable_extension SYSTEM PRIVATE ${PAIMON_CPP_INCLUDE})
 
+# Keep the extension's user-facing feature checks aligned with paimon-cpp.
+set(PAIMON_FEATURE_DEFINITIONS
+  PAIMON_ENABLE_OSS=$<BOOL:${PAIMON_ENABLE_OSS}>
+  PAIMON_ENABLE_S3=$<BOOL:${PAIMON_ENABLE_S3}>
+  PAIMON_ENABLE_REST=$<BOOL:${PAIMON_ENABLE_REST}>)
+target_compile_definitions(${EXTENSION_NAME} PRIVATE ${PAIMON_FEATURE_DEFINITIONS})
+target_compile_definitions(${TARGET_NAME}_loadable_extension PRIVATE ${PAIMON_FEATURE_DEFINITIONS})
+
 # Build paimon-cpp before building the extension
 add_dependencies(${EXTENSION_NAME} paimon_cpp_ep)
 add_dependencies(${TARGET_NAME}_loadable_extension paimon_cpp_ep)

--- a/src/paimon_storage/paimon_catalog.cpp
+++ b/src/paimon_storage/paimon_catalog.cpp
@@ -117,6 +117,10 @@ map<string, string> PaimonCatalog::GetPaimonOptions(ClientContext &context, cons
 		paimon_options[paimon::CatalogOptions::METASTORE] = metastore.value();
 
 		if (StringUtil::CIEquals(metastore.value(), "rest")) {
+#if !PAIMON_ENABLE_REST
+			throw InvalidInputException(
+			    "Paimon extension was built without REST catalog support; rebuild with -DPAIMON_ENABLE_REST=ON");
+#else
 			auto uri = TryGetPaimonOptionValue(input_options, "uri");
 			if (!uri.has_value() || uri->empty()) {
 				throw InvalidInputException("URI is required when METASTORE is 'rest'");
@@ -136,6 +140,7 @@ map<string, string> PaimonCatalog::GetPaimonOptions(ClientContext &context, cons
 			if (token.has_value()) {
 				paimon_options[paimon::CatalogOptions::TOKEN] = token.value();
 			}
+#endif
 		}
 	}
 
@@ -156,9 +161,19 @@ map<string, string> PaimonCatalog::GetPaimonOptions(ClientContext &context, cons
 	const bool is_s3 = StringUtil::StartsWith(normalized_path, S3_PATH_PREFIX);
 
 	if (is_oss) {
+#if !PAIMON_ENABLE_OSS
+		throw InvalidInputException(
+		    "Paimon extension was built without OSS file system support; rebuild with -DPAIMON_ENABLE_OSS=ON");
+#else
 		paimon_options[paimon::Options::FILE_SYSTEM] = "oss";
+#endif
 	} else if (is_s3) {
+#if !PAIMON_ENABLE_S3
+		throw InvalidInputException(
+		    "Paimon extension was built without S3 file system support; rebuild with -DPAIMON_ENABLE_S3=ON");
+#else
 		paimon_options[paimon::Options::FILE_SYSTEM] = "s3";
+#endif
 	} else {
 		paimon_options[paimon::Options::FILE_SYSTEM] = "local";
 	}


### PR DESCRIPTION
## Summary
- Propagate enabled Paimon component flags to the extension build.
- Reject disabled OSS, S3, and REST features before catalog setup.

## Testing
- Built the release loadable extension.
- Ran `test/sql/paimon_catalog.test`.
- Compiled the catalog source with all three feature flags disabled.